### PR TITLE
Tags in code

### DIFF
--- a/databind.toml
+++ b/databind.toml
@@ -2,9 +2,5 @@
 random_var_names = false
 # Change the display name of randomized vars
 var_display_names = false
-# Whether to generate function tags in minecraft/tags/functions
-generate_func_tags = true
-# Functions to generate tags for
-func_tag_inclusions = ["tick", "load"]
 # Files to transpile
 to_transpile = ["**/*.databind"]

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -17,10 +17,6 @@ be passed with the `-c` or `--config` option.
 +--------------------------------------------+---------------------------------------------------------------------------------------+
 | ``var_display_names = false``              | Whether to update scoreboard display names for randomized variables                   |
 +--------------------------------------------+---------------------------------------------------------------------------------------+
-| ``generate_func_tags = false``             | Whether to automatically generate tags in ``minecraft/tags/functions``                |
-+--------------------------------------------+---------------------------------------------------------------------------------------+
-| ``func_tag_inclusions = ["load", "tick"]`` | The functions to generate tags for if ``generate_func_tags`` is true                  |
-+--------------------------------------------+---------------------------------------------------------------------------------------+
 | ``to_transpile = ["**/*.databind"]``       | Specify what files to transpile using globs                                           |
 +--------------------------------------------+---------------------------------------------------------------------------------------+
 | ``output = String``                        | The output file or folder. If unspecified, creates new folder ending in ``.databind`` |
@@ -32,8 +28,9 @@ CLI arguments
 Most options that can be set in the ``databind.toml`` file can
 also be set using CLI arguments. The CLI arguments use dashes
 instead of underscores (eg. ``--generate-func-tags`` instead
-of ``generate_func_tags``).
+of ``generate_func_tags``) and may have different names or
+shorthand.
 
 Example use:
 
-``databind --generate-func-tags -c config.toml -o ./out ./datapack``
+``databind -c config.toml -o ./out ./datapack``

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,11 +31,6 @@ pub fn get_cli_matches<'a>() -> clap::ArgMatches<'a> {
                 .help("Ignore the config file. Used for testing"),
         )
         .arg(
-            Arg::with_name("generate-func-tags")
-                .long("generate-func-tags")
-                .help("Generate tags for functions in minecraft/tags/functions"),
-        )
-        .arg(
             Arg::with_name("random-var-names")
                 .long("random-var-names")
                 .help(

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,9 +89,6 @@ fn main() -> std::io::Result<()> {
     if matches.is_present("var-display-names") {
         transpiler_settings.var_display_names = true;
     }
-    if matches.is_present("generate-func-tags") {
-        transpiler_settings.generate_func_tags = true;
-    }
     if matches.is_present("output") {
         transpiler_settings.output = Some(matches.value_of("output").unwrap().to_string());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,14 +31,14 @@ fn get_namespace(functions_path: &Path) -> &str {
     namespace
 }
 
-/// Return the value of a tag file for a function
-fn create_func_json(functions_path: &Path, func_name: &str) -> String {
-    format!(
-        "{{\"values\": [\"{}:{}\"]}}",
-        get_namespace(functions_path),
-        func_name
-    )
-}
+// /// Return the value of a tag file for a function
+// fn create_func_json(functions_path: &Path, func_name: &str) -> String {
+//     format!(
+//         "{{\"values\": [\"{}:{}\"]}}",
+//         get_namespace(functions_path),
+//         func_name
+//     )
+// }
 
 /// Convert multiple globs into a `Vec<PathBuf>`
 fn to_transpile(globs: &Vec<String>, prefix: &str) -> Vec<PathBuf> {
@@ -110,6 +110,7 @@ fn main() -> std::io::Result<()> {
 
     if datapack_is_dir {
         let mut var_map: HashMap<String, String> = HashMap::new();
+        let mut tag_map: HashMap<String, Vec<String>> = HashMap::new();
         let mut target_folder: String;
 
         if let Some(output) = &transpiler_settings.output {
@@ -172,6 +173,7 @@ fn main() -> std::io::Result<()> {
                         files,
                         filename_to_index,
                         vars,
+                        mut tags,
                     ) = transpiled
                     {
                         var_map = vars;
@@ -182,32 +184,32 @@ fn main() -> std::io::Result<()> {
                                 let full_path =
                                     format!("{}/{}.mcfunction", target_path, filename_no_ext);
 
-                                // Create <function>.json if it does not exist and if it is in the inclusions list
-                                if transpiler_settings.generate_func_tags
-                                    && transpiler_settings
-                                        .func_tag_inclusions
-                                        .contains(&filename_no_ext.to_string())
-                                {
-                                    let json_path_str = format!(
-                                        "{}/data/minecraft/tags/functions/{}.json",
-                                        datapack, filename_no_ext
-                                    );
-                                    let json_path = Path::new(&json_path_str);
+                                // // Create <function>.json if it does not exist and if it is in the inclusions list
+                                // if transpiler_settings.generate_func_tags
+                                //     && transpiler_settings
+                                //         .func_tag_inclusions
+                                //         .contains(&filename_no_ext.to_string())
+                                // {
+                                //     let json_path_str = format!(
+                                //         "{}/data/minecraft/tags/functions/{}.json",
+                                //         datapack, filename_no_ext
+                                //     );
+                                //     let json_path = Path::new(&json_path_str);
 
-                                    if !json_path.exists() {
-                                        let new_json_path_str = format!(
-                                            "{}/data/minecraft/tags/functions/{}.json",
-                                            target_folder, filename_no_ext
-                                        );
-                                        let new_json_path = Path::new(&new_json_path_str);
+                                //     if !json_path.exists() {
+                                //         let new_json_path_str = format!(
+                                //             "{}/data/minecraft/tags/functions/{}.json",
+                                //             target_folder, filename_no_ext
+                                //         );
+                                //         let new_json_path = Path::new(&new_json_path_str);
 
-                                        fs::create_dir_all(&new_json_path.parent().unwrap())?;
-                                        fs::write(
-                                            new_json_path,
-                                            create_func_json(path, filename_no_ext),
-                                        )?;
-                                    }
-                                }
+                                //         fs::create_dir_all(&new_json_path.parent().unwrap())?;
+                                //         fs::write(
+                                //             new_json_path,
+                                //             create_func_json(path, filename_no_ext),
+                                //         )?;
+                                //     }
+                                // }
 
                                 fs::write(full_path, &files[0])?;
                                 continue;
@@ -215,31 +217,41 @@ fn main() -> std::io::Result<()> {
 
                             let full_path = format!("{}/{}.mcfunction", target_path, key);
 
-                            // Create <function>.json if it does not exist and if it is in the inclusions list
-                            if transpiler_settings.generate_func_tags
-                                && transpiler_settings.func_tag_inclusions.contains(key)
-                            {
-                                let json_path_str = format!(
-                                    "{}/data/minecraft/tags/functions/{}.json",
-                                    datapack, key
-                                );
-                                let json_path = Path::new(&json_path_str);
+                            // // Create <function>.json if it does not exist and if it is in the inclusions list
+                            // if transpiler_settings.generate_func_tags
+                            //     && transpiler_settings.func_tag_inclusions.contains(key)
+                            // {
+                            //     let json_path_str = format!(
+                            //         "{}/data/minecraft/tags/functions/{}.json",
+                            //         datapack, key
+                            //     );
+                            //     let json_path = Path::new(&json_path_str);
 
-                                // Create <function>.json if it does not exist
-                                if !json_path.exists() {
-                                    let new_json_path_str = format!(
-                                        "{}/data/minecraft/tags/functions/{}.json",
-                                        target_folder, key,
-                                    );
-                                    let new_json_path = Path::new(&new_json_path_str);
+                            //     // Create <function>.json if it does not exist
+                            //     if !json_path.exists() {
+                            //         let new_json_path_str = format!(
+                            //             "{}/data/minecraft/tags/functions/{}.json",
+                            //             target_folder, key,
+                            //         );
+                            //         let new_json_path = Path::new(&new_json_path_str);
 
-                                    fs::create_dir_all(&new_json_path.parent().unwrap())?;
-                                    fs::write(new_json_path, create_func_json(path, key))?;
-                                }
-                            }
+                            //         fs::create_dir_all(&new_json_path.parent().unwrap())?;
+                            //         fs::write(new_json_path, create_func_json(path, key))?;
+                            //     }
+                            // }
 
                             fs::write(full_path, &files[*value])?;
+
+                            // Add namespace prefix to function in tag map
+                            for (_, funcs) in tags.iter_mut() {
+                                if funcs.contains(key) {
+                                    let i = funcs.iter().position(|x| x == key).unwrap();
+                                    funcs[i] = format!("{}:{}", get_namespace(entry.path()), key);
+                                }
+                            }
                         }
+
+                        tag_map.extend(tags);
                     }
                 } else {
                     let filename = path.file_name().unwrap().to_str().unwrap();
@@ -247,6 +259,35 @@ fn main() -> std::io::Result<()> {
                     fs::copy(entry.path(), full_path)?;
                 }
             }
+        }
+
+        // Write tag files
+        fs::create_dir_all(format!("{}/data/minecraft/tags/functions", target_folder))?;
+
+        for (tag, funcs) in tag_map.iter() {
+            let mut tag_file = String::from("{\n  \"values\": [");
+
+            let mut first_func = true;
+
+            for func in funcs.iter() {
+                if !first_func {
+                    tag_file.push(',');
+                } else {
+                    first_func = false;
+                }
+                tag_file.push_str(&format!("\n    \"{}\"", func)[..]);
+            }
+
+            tag_file.push_str("\n  ]\n}\n");
+
+            // Write tag file
+            fs::write(
+                format!(
+                    "{}/data/minecraft/tags/functions/{}.json",
+                    target_folder, tag
+                ),
+                tag_file,
+            )?;
         }
     } else {
         let content = fs::read_to_string(datapack).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,15 +31,6 @@ fn get_namespace(functions_path: &Path) -> &str {
     namespace
 }
 
-// /// Return the value of a tag file for a function
-// fn create_func_json(functions_path: &Path, func_name: &str) -> String {
-//     format!(
-//         "{{\"values\": [\"{}:{}\"]}}",
-//         get_namespace(functions_path),
-//         func_name
-//     )
-// }
-
 /// Convert multiple globs into a `Vec<PathBuf>`
 fn to_transpile(globs: &Vec<String>, prefix: &str) -> Vec<PathBuf> {
     let mut to_transpile: Vec<PathBuf> = Vec::new();
@@ -184,61 +175,11 @@ fn main() -> std::io::Result<()> {
                                 let full_path =
                                     format!("{}/{}.mcfunction", target_path, filename_no_ext);
 
-                                // // Create <function>.json if it does not exist and if it is in the inclusions list
-                                // if transpiler_settings.generate_func_tags
-                                //     && transpiler_settings
-                                //         .func_tag_inclusions
-                                //         .contains(&filename_no_ext.to_string())
-                                // {
-                                //     let json_path_str = format!(
-                                //         "{}/data/minecraft/tags/functions/{}.json",
-                                //         datapack, filename_no_ext
-                                //     );
-                                //     let json_path = Path::new(&json_path_str);
-
-                                //     if !json_path.exists() {
-                                //         let new_json_path_str = format!(
-                                //             "{}/data/minecraft/tags/functions/{}.json",
-                                //             target_folder, filename_no_ext
-                                //         );
-                                //         let new_json_path = Path::new(&new_json_path_str);
-
-                                //         fs::create_dir_all(&new_json_path.parent().unwrap())?;
-                                //         fs::write(
-                                //             new_json_path,
-                                //             create_func_json(path, filename_no_ext),
-                                //         )?;
-                                //     }
-                                // }
-
                                 fs::write(full_path, &files[0])?;
                                 continue;
                             }
 
                             let full_path = format!("{}/{}.mcfunction", target_path, key);
-
-                            // // Create <function>.json if it does not exist and if it is in the inclusions list
-                            // if transpiler_settings.generate_func_tags
-                            //     && transpiler_settings.func_tag_inclusions.contains(key)
-                            // {
-                            //     let json_path_str = format!(
-                            //         "{}/data/minecraft/tags/functions/{}.json",
-                            //         datapack, key
-                            //     );
-                            //     let json_path = Path::new(&json_path_str);
-
-                            //     // Create <function>.json if it does not exist
-                            //     if !json_path.exists() {
-                            //         let new_json_path_str = format!(
-                            //             "{}/data/minecraft/tags/functions/{}.json",
-                            //             target_folder, key,
-                            //         );
-                            //         let new_json_path = Path::new(&new_json_path_str);
-
-                            //         fs::create_dir_all(&new_json_path.parent().unwrap())?;
-                            //         fs::write(new_json_path, create_func_json(path, key))?;
-                            //     }
-                            // }
 
                             fs::write(full_path, &files[*value])?;
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,6 @@ use serde_derive::Deserialize;
 pub struct Settings {
     pub random_var_names: bool,
     pub var_display_names: bool,
-    pub generate_func_tags: bool,
     pub func_tag_inclusions: Vec<String>,
     pub to_transpile: Vec<String>,
     pub output: Option<String>,
@@ -17,7 +16,6 @@ impl Default for Settings {
         Settings {
             random_var_names: false,
             var_display_names: false,
-            generate_func_tags: false,
             func_tag_inclusions: vec![String::from("tick"), String::from("load")],
             to_transpile: vec![String::from("**/*.databind")],
             output: None,

--- a/src/token.rs
+++ b/src/token.rs
@@ -14,6 +14,10 @@ pub enum Token {
     FuncName(String),
     /// End a function definition
     EndFunc,
+    /// Add a tag to a function
+    Tag,
+    /// The name of a tag
+    TagName(String),
     /// Call a funcition
     CallFunc,
     /// Start a while loop

--- a/src/transpiler/mod.rs
+++ b/src/transpiler/mod.rs
@@ -16,15 +16,20 @@ pub enum TranspileReturn {
     /// - `String` - The contents of the file
     /// - `HashMap<String, usize>` - A map of filenames to indexes
     SingleContentsAndMap(String, HashMap<String, String>),
-    /// The contents of multiple files
+    /// The contents of multiple files as well as a map of tags to functions
     ///
     /// # Arguments
     ///
     /// - `Vec<String>` - A list of file contents
     /// - `HashMap<String, usize>` - A map of filenames to indexes
     ///    The first key will always be `""`, which is the main file transpiled
-    MultiFile(Vec<String>, HashMap<String, usize>),
-    /// The contents of multiple files as well as a variable map
+    /// - `HashMap<String, Vec<String>>` - A map of tags to functions
+    MultiFile(
+        Vec<String>,
+        HashMap<String, usize>,
+        HashMap<String, Vec<String>>,
+    ),
+    /// The contents of multiple files as well as a variable map and a map of tags to functions
     ///
     /// # Arguments
     ///
@@ -32,7 +37,13 @@ pub enum TranspileReturn {
     /// - `HashMap<String, usize>` - A map of filenames to indexes
     ///    The first key will always be `""`, which is the main file transpiled
     /// - `HashMap<String, String>` - A map of variable names used in files to randomized names
-    MultiFileAndMap(Vec<String>, HashMap<String, usize>, HashMap<String, String>),
+    /// - `HashMap<String, Vec<String>>` - A map of tags to functions
+    MultiFileAndMap(
+        Vec<String>,
+        HashMap<String, usize>,
+        HashMap<String, String>,
+        HashMap<String, Vec<String>>,
+    ),
 }
 
 pub struct Transpiler<'a> {

--- a/src/transpiler/tokenize.rs
+++ b/src/transpiler/tokenize.rs
@@ -96,6 +96,10 @@ impl Transpiler<'_> {
                         tokens.push(Token::EndFunc);
                         building_keyword = false;
                     }
+                    "tag" => {
+                        tokens.push(Token::Tag);
+                        building_token = Token::Tag;
+                    }
                     "call" => {
                         tokens.push(Token::CallFunc);
                         building_token = Token::CallFunc;
@@ -282,6 +286,17 @@ impl Transpiler<'_> {
                             }
                         }
                     },
+                    Token::Tag => {
+                        if self.current_char.is_whitespace() {
+                            tokens.push(Token::TagName(current_keyword));
+                            building_keyword = false;
+                            building_token = Token::None;
+                            current_keyword = String::new();
+                            first_whitespace = false;
+                        } else {
+                            current_keyword.push(self.current_char);
+                        }
+                    }
                     _ => {}
                 }
             } else if self.current_char == '#'

--- a/src/transpiler/while_convert.rs
+++ b/src/transpiler/while_convert.rs
@@ -64,7 +64,6 @@ impl Transpiler<'_> {
                             &Settings {
                                 random_var_names: false,
                                 var_display_names: false,
-                                generate_func_tags: false,
                                 func_tag_inclusions: Vec::new(),
                                 to_transpile: Vec::new(),
                                 output: None,

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -25,9 +25,7 @@ fn test_config() {
         )
     );
 
-    let expected_funcs = ["main", "should_be_made", "should_not_be_made"];
-    let expected_tags = ["main", "should_be_made"];
-    let unexpected_tags = ["should_not_be_made"];
+    let expected_funcs = ["different_extension", "should_be_made", "func1", "func2"];
 
     path.pop();
     path.push("test_config.databind/data");
@@ -44,139 +42,9 @@ fn test_config() {
     path.pop();
     path.pop();
 
-    // Check if tag files are correctly placed
-    path.push("minecraft/tags/functions");
-    for file in expected_tags.iter() {
-        path.push(format!("{}.json", file));
-        assert!(fs::metadata(&path).is_ok());
-        println!("test_config: Tag {}.json exists", file);
-        path.pop();
-    }
-
-    // Ensure unexpected tag files do not exist
-    for file in unexpected_tags.iter() {
-        path.push(format!("{}.tags", file));
-        assert!(fs::metadata(&path).is_err());
-        println!(
-            "test_config: Tag {}.tags doesn't (and shouldn't) exist",
-            file
-        );
-        path.pop();
-    }
-
     // Delete generated folder
     let mut out_path = tests::resources();
     out_path.push("test_config.databind");
-    fs::remove_dir_all(out_path).unwrap();
-}
-
-/// Test that CLI options are properly followed
-#[test]
-fn test_cli_args_no_tags() {
-    let mut path = tests::resources();
-    path.push("test_cli_args");
-    let path_str = path.to_str().unwrap();
-
-    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
-
-    let expected_funcs = ["tick", "a_function"];
-    let unexpected_tags = ["tick", "a_function"];
-
-    path.pop();
-    path.push("test_cli_args.databind/data");
-
-    // Check if function files are correctly placed
-    path.push("test/functions");
-    for file in expected_funcs.iter() {
-        path.push(format!("{}.mcfunction", file));
-        assert!(fs::metadata(&path).is_ok());
-        println!("test_cli_args_no_tags: Function {}.mcfunction exists", file);
-        path.pop();
-    }
-
-    path.pop();
-    path.pop();
-
-    // Ensure unexpected tag files do not exist
-    path.push("minecraft/tags/functions");
-    for file in unexpected_tags.iter() {
-        path.push(format!("{}.json", file));
-        assert!(fs::metadata(&path).is_err());
-        println!(
-            "test_cli_args_no_tags: Tag {}.json doesn't (and shouldn't) exist",
-            file
-        );
-        path.pop();
-    }
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_cli_args.databind");
-    fs::remove_dir_all(out_path).unwrap();
-}
-
-#[test]
-fn test_cli_args_generate_tags() {
-    let mut path = tests::resources();
-    path.push("test_cli_args");
-    let path_str = path.to_str().unwrap();
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path_str,
-            "--ignore-config",
-            "--generate-func-tags",
-        ],
-    );
-
-    let expected_funcs = ["tick", "a_function"];
-    let expected_tags = ["tick"];
-    let unexpected_tags = ["a_function"];
-
-    path.pop();
-    path.push("test_cli_args.databind/data");
-
-    // Check if function files are correctly placed
-    path.push("test/functions");
-    for file in expected_funcs.iter() {
-        path.push(format!("{}.mcfunction", file));
-        assert!(fs::metadata(&path).is_ok());
-        println!(
-            "test_cli_args_generate_tags: Function {}.mcfunction exists",
-            file
-        );
-        path.pop();
-    }
-
-    path.pop();
-    path.pop();
-
-    // Check if tag files are correctly placed
-    path.push("minecraft/tags/functions");
-    for file in expected_tags.iter() {
-        path.push(format!("{}.json", file));
-        assert!(fs::metadata(&path).is_ok());
-        println!("test_cli_args_generate_tags: Tag {}.json exists", file);
-        path.pop();
-    }
-
-    // Ensure unexpected tag files do not exist
-    for file in unexpected_tags.iter() {
-        path.push(format!("{}.json", file));
-        assert!(fs::metadata(&path).is_err());
-        println!(
-            "test_cli_args_generate_tags: Tag {}.json doesn't (and shouldn't) exist",
-            file
-        );
-        path.pop();
-    }
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_cli_args.databind");
     fs::remove_dir_all(out_path).unwrap();
 }
 

--- a/tests/func_tests.rs
+++ b/tests/func_tests.rs
@@ -10,20 +10,11 @@ fn test_file_structure() {
     let mut path = tests::resources();
     path.push("test_file_structure");
     let path_str = path.to_str().unwrap();
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path_str,
-            "--generate-func-tags",
-            "--ignore-config",
-        ],
-    );
+    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
 
-    let expected_funcs = ["load", "tick", "first_func", "second_func"];
+    let expected_funcs = ["main", "load", "tick", "first_func", "second_func"];
     let expected_tags = ["load", "tick"];
-    let unexpected_tags = ["first_func", "second_func"];
+    let unexpected_tags = ["main", "first_func", "second_func"];
 
     path.pop();
     path.push("test_file_structure.databind/data");

--- a/tests/resources/test_config/data/test/functions/different_extension.test
+++ b/tests/resources/test_config/data/test/functions/different_extension.test
@@ -1,0 +1,2 @@
+:func func1
+:endfunc

--- a/tests/resources/test_config/data/test/functions/main.databind
+++ b/tests/resources/test_config/data/test/functions/main.databind
@@ -1,7 +1,0 @@
-:func should_be_made
-say Hello, World!
-:endfunc
-
-:func should_not_be_made
-say Hello, World!
-:endfunc

--- a/tests/resources/test_config/data/test/functions/should_be_made.databind
+++ b/tests/resources/test_config/data/test/functions/should_be_made.databind
@@ -1,0 +1,2 @@
+:func func2
+:endfunc

--- a/tests/resources/test_config/databind.toml
+++ b/tests/resources/test_config/databind.toml
@@ -1,5 +1,3 @@
 random_var_names = false
 var_display_names = false
-generate_func_tags = true
-func_tag_inclusions = ["main", "should_be_made"]
-to_transpile = ["**/*.databind"]
+to_transpile = ["**/*.databind", "**/*.test"]

--- a/tests/resources/test_file_structure/data/test/functions/main.databind
+++ b/tests/resources/test_file_structure/data/test/functions/main.databind
@@ -1,4 +1,12 @@
+:func load
+:tag load
 :var test .= 0
+:endfunc
+
+:func tick
+:tag tick
+execute if :tvar test matches 1 run say test is 1
+:endfunc
 
 :func first_func
 say first_func says hi

--- a/tests/resources/test_file_structure/data/test/functions/tick.databind
+++ b/tests/resources/test_file_structure/data/test/functions/tick.databind
@@ -1,1 +1,0 @@
-execute if :tvar test matches 1 run say test is 1

--- a/tests/resources/test_no_config_out/should_not_be_made.toml
+++ b/tests/resources/test_no_config_out/should_not_be_made.toml
@@ -1,5 +1,3 @@
 random_var_names = false
 var_display_names = false
-generate_func_tags = true
-func_tag_inclusions = ["tick", "load"]
 to_transpile = ["**/*.databind"]

--- a/tests/resources/test_tag_generation/data/test/functions/main.databind
+++ b/tests/resources/test_tag_generation/data/test/functions/main.databind
@@ -1,0 +1,13 @@
+:func load
+:tag load
+:tag second_tag
+:endfunc
+
+:func tick
+:tag tick
+:tag second_tag
+:endfunc
+
+:func func3
+:tag func3
+:endfunc

--- a/tests/resources/test_tag_syntax/data/test/functions/main.databind
+++ b/tests/resources/test_tag_syntax/data/test/functions/main.databind
@@ -1,0 +1,11 @@
+:func func1 :tag func1_tag :tag all_tag
+:endfunc
+
+:func func2 :tag func2_tag
+:tag all_tag
+:endfunc
+
+:func func3
+:tag func3_tag
+:tag all_tag
+:endfunc

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -1,0 +1,121 @@
+use std::fs;
+
+mod tests;
+
+/// Test that tags are properly generated
+#[test]
+fn test_tag_generation() {
+    let mut path = tests::resources();
+    path.push("test_tag_generation");
+    let path_str = path.to_str().unwrap();
+
+    println!("{}", path_str);
+
+    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
+
+    let expected_funcs = ["main", "load", "tick", "func3"];
+    let expected_tags = ["load", "tick", "second_tag", "func3"];
+    let unexpected_tags = ["main"];
+
+    path.pop();
+    path.push("test_tag_generation.databind/data");
+
+    // Check if function files are correctly placed
+    path.push("test/functions");
+    for file in expected_funcs.iter() {
+        path.push(format!("{}.mcfunction", file));
+        assert!(fs::metadata(&path).is_ok());
+        println!("test_tag_generation: Function {}.mcfunction exists", file);
+        path.pop();
+    }
+
+    path.pop();
+    path.pop();
+
+    // Check if tag files are correctly placed
+    path.push("minecraft/tags/functions");
+    for file in expected_tags.iter() {
+        path.push(format!("{}.json", file));
+        assert!(fs::metadata(&path).is_ok());
+        println!("test_tag_generation: Tag {}.json exists", file);
+        path.pop();
+    }
+
+    // Ensure unexpected tag files do not exist
+    for file in unexpected_tags.iter() {
+        path.push(format!("{}.json", file));
+        assert!(fs::metadata(&path).is_err());
+        println!(
+            "test_tag_generation: Tag {}.json doesn't (and shouldn't) exist",
+            file
+        );
+        path.pop();
+    }
+
+    path.pop();
+    path.pop();
+
+    // Delete generated folder
+    let mut out_path = tests::resources();
+    out_path.push("test_tag_generation.databind");
+    fs::remove_dir_all(out_path).unwrap();
+}
+
+/// Test multiple ways to format :tag code
+#[test]
+fn test_tag_syntax() {
+    let mut path = tests::resources();
+    path.push("test_tag_syntax");
+    let path_str = path.to_str().unwrap();
+
+    println!("{}", path_str);
+
+    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
+
+    let expected_funcs = ["main", "func1", "func2", "func3"];
+    let expected_tags = ["func1_tag", "func2_tag", "func3_tag", "all_tag"];
+    let unexpected_tags = ["main"];
+
+    path.pop();
+    path.push("test_tag_syntax.databind/data");
+
+    // Check if function files are correctly placed
+    path.push("test/functions");
+    for file in expected_funcs.iter() {
+        path.push(format!("{}.mcfunction", file));
+        assert!(fs::metadata(&path).is_ok());
+        println!("test_tag_syntax: Function {}.mcfunction exists", file);
+        path.pop();
+    }
+
+    path.pop();
+    path.pop();
+
+    // Check if tag files are correctly placed
+    path.push("minecraft/tags/functions");
+    for file in expected_tags.iter() {
+        path.push(format!("{}.json", file));
+        assert!(fs::metadata(&path).is_ok());
+        println!("test_tag_syntax: Tag {}.json exists", file);
+        path.pop();
+    }
+
+    // Ensure unexpected tag files do not exist
+    for file in unexpected_tags.iter() {
+        path.push(format!("{}.json", file));
+        assert!(fs::metadata(&path).is_err());
+        println!(
+            "test_tag_syntax: Tag {}.json doesn't (and shouldn't) exist",
+            file
+        );
+        path.pop();
+    }
+
+    path.pop();
+    path.pop();
+
+    // Delete generated folder
+    let mut out_path = tests::resources();
+    out_path.push("test_tag_syntax.databind");
+    fs::remove_dir_all(out_path).unwrap();
+}


### PR DESCRIPTION
Closes #6 

Adds a new `:tag` keyword to specify function tags in code.
Multiple formats are supported (unintentionally but works for me):

```databind
:func function
:tag load
:tag a_function
tellraw @a "Hello, World!"
:endfunc
```

```databind
:func function :tag load :tag a_function
tellraw @a "Hello, World!"
:endfunc
```