### PR TITLE
Add create subcommand to create projects

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,9 @@
-use clap::{App, Arg};
+use clap::{App, Arg, SubCommand};
 
 /// Set up Clap CLI and get arguments
 pub fn get_cli_matches<'a>() -> clap::ArgMatches<'a> {
     App::new("Databind")
+        .setting(clap::AppSettings::SubcommandsNegateReqs)
         .version("0.1.0")
         .author("Adam Thompson-Sharpe <adamthompsonsharpe@gmail.com>")
         .about("Expand the functionality of Minecraft Datapacks.")
@@ -44,6 +45,32 @@ pub fn get_cli_matches<'a>() -> clap::ArgMatches<'a> {
                 .help(
                     "Change the display name of variables in-game to hide extra characters. \
                 Only relevant with --random-var-names",
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("create")
+                .about("Create a new project")
+                .arg(
+                    Arg::with_name("name")
+                        .help("The name of the project")
+                        .required(true)
+                        .value_name("NAME"),
+                )
+                .arg(
+                    Arg::with_name("description")
+                        .help("The pack description")
+                        .default_value("A databind pack")
+                        .long("description")
+                        .alias("desc")
+                        .takes_value(true)
+                        .value_name("DESCRIPTION"),
+                )
+                .arg(
+                    Arg::with_name("path")
+                        .help("The path to create the pack in")
+                        .long("path")
+                        .takes_value(true)
+                        .value_name("PATH"),
                 ),
         )
         .get_matches()

--- a/src/create_project.rs
+++ b/src/create_project.rs
@@ -34,7 +34,15 @@ fn dir_empty(path: &dyn AsRef<Path>) -> std::io::Result<bool> {
 ///
 /// - `args` - Matches from the create subcommand
 pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
+    let allowed_chars = "abcdefghijklmnopqrstuvwxyz0123456789_-.";
+
     let name = args.value_of("name").unwrap();
+
+    if name.chars().into_iter().any(|x| !allowed_chars.contains(x)) {
+        println!("Project name contains disallowed characters");
+        std::process::exit(1);
+    }
+
     let description = args.value_of("description").unwrap().to_string();
     let base_path = if args.is_present("path") {
         args.value_of("path").unwrap()

--- a/src/create_project.rs
+++ b/src/create_project.rs
@@ -1,0 +1,88 @@
+use serde_derive::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn make_pack_mcmeta(description: String) -> Result<String, serde_json::Error> {
+    #[derive(Serialize)]
+    struct Pack {
+        pack_format: u8,
+        description: String,
+    }
+
+    #[derive(Serialize)]
+    struct PackMcMeta {
+        pack: Pack,
+    }
+
+    let pack = PackMcMeta {
+        pack: Pack {
+            pack_format: 6,
+            description: description,
+        },
+    };
+
+    serde_json::to_string(&pack)
+}
+
+fn dir_empty(path: &dyn AsRef<Path>) -> std::io::Result<bool> {
+    Ok(path.as_ref().read_dir()?.next().is_none())
+}
+
+/// Handle the create subcommand
+///
+/// # Arguments
+///
+/// - `args` - Matches from the create subcommand
+pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
+    let name = args.value_of("name").unwrap();
+    let description = args.value_of("description").unwrap().to_string();
+    let base_path = if args.is_present("path") {
+        args.value_of("path").unwrap()
+    } else {
+        name
+    };
+
+    let mut path = PathBuf::new();
+    path.push("./");
+    path.push(base_path);
+
+    let metadata = fs::metadata(&path);
+
+    if metadata.is_ok() {
+        let unwrapped = metadata.unwrap();
+        if unwrapped.is_file() || unwrapped.is_dir() && !dir_empty(&path)? {
+            println!(
+                "Path {} is an already existant file or non-empty folder",
+                base_path
+            );
+            std::process::exit(1);
+        }
+    }
+
+    path.push(format!("data/{}/functions", name));
+    fs::create_dir_all(&path)?;
+
+    // Create main.databind
+    path.push("main.databind");
+    fs::write(
+        &path,
+        "\
+    :func main\n\
+    :tag load\n\
+    tellraw @a \"Hello, World!\"\n\
+    :endfunc\n",
+    )?;
+
+    path.pop();
+    path.pop();
+    path.pop();
+    path.pop();
+
+    // Create pack.mcmeta
+    let pack_mcmeta = make_pack_mcmeta(description)?;
+    path.push("pack.mcmeta");
+    fs::write(&path, pack_mcmeta)?;
+
+    println!("Created project {} in {}", name, base_path);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 mod cli;
+mod create_project;
 mod settings;
 mod token;
 mod transpiler;
@@ -53,6 +54,11 @@ fn merge_globs(globs: &Vec<String>, prefix: &str) -> Vec<PathBuf> {
 /// Transpiles provided files and folders to normal `.mcfunction` files
 fn main() -> std::io::Result<()> {
     let matches = cli::get_cli_matches();
+
+    // Check if create command is used
+    if let Some(subcommand) = matches.subcommand {
+        return create_project::create_project(subcommand.matches);
+    }
 
     let config_path_str: String;
 


### PR DESCRIPTION
Closes #15 

Adds a subcommand to create new projects.

```txt
USAGE:
    databind create [OPTIONS] <NAME>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --description <DESCRIPTION>    The pack description [default: A databind pack]
        --path <PATH>                  The path to create the pack in
```