### PR TITLE
Remove support for single-file compilation

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -36,7 +36,7 @@ Using the CLI
       -o, --out <output>       The output file or directory
 
    ARGS:
-      <DATAPACK>    The datapack (or file) to transpile
+      <DATAPACK>    The Databind project to transpile
 
    SUBCOMMANDS:
       create    Create a new project

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,12 +4,11 @@ Databind CLI
 What Can Be Transpiled
 ----------------------
 
-Either single mcfunction files or entire datapack folders can be transpiled.
-When transpiling an entire folder, Databind will look for ``.databind`` files and
-leave other files alone. Using a project folder as opposed to a single file
-is required for using ``:func``.
+Databind transpiles Databind projects (see :ref:`Creating a Project`).
+Databind will look for included files (``**/*.databind`` by default) and
+leave other files alone.
 
-Note that the namespace inference used for ``:func`` assumes a typical datapack
+Note that the namespace inference used for ``:func`` assumes a proper
 file structure (``<datapack>/data/<namespace>/functions`` for functions), but it
 **does not check if this is the case.** A ``minecraft/tags/functions/`` folder may
 be generated in an unexpected place if an invalid folder is passed.
@@ -46,13 +45,12 @@ Using the CLI
 From an Installation
 ^^^^^^^^^^^^^^^^^^^^
 
-To transpile a single file, run ``databind file.databind``. A file called
-``databind-out.mcfunction`` will be generated. To transpile a datapack folder,
-run ``databind path/to/datapack``.  
+When installed, you can access the CLI by running ``databind`` in any command line.
+Running ``databind --help`` will output the text above.
 
 With ``cargo run``
 ^^^^^^^^^^^^^^^^^^
 
 After building Databind yourself, you can use ``cargo run`` to run it. Everything
 works almost the exact same. You just need to add two dashes (``--``) after ``run``
-(eg. ``cargo run -- file.databind`` or ``cargo run -- --help``).
+(eg. ``cargo run -- --help``).

--- a/docs/examples/while_examples/loop_until_false.rst
+++ b/docs/examples/while_examples/loop_until_false.rst
@@ -10,10 +10,13 @@ Example
 
 .. code-block:: databind
 
+   :func load
+   :tag load
    :var bool .= 1
    :while :tvar bool matches 1
    tellraw @a "Bool is true"
    :endwhile
+   :endfunc
    
 Transpiled
 ----------

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,7 +9,7 @@ pub fn get_cli_matches<'a>() -> clap::ArgMatches<'a> {
         .about("Expand the functionality of Minecraft Datapacks.")
         .arg(
             Arg::with_name("DATAPACK")
-                .help("The datapack (or file) to transpile")
+                .help("The Databind project to transpile")
                 .required(true),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,28 +257,8 @@ fn main() -> std::io::Result<()> {
             )?;
         }
     } else {
-        let content = fs::read_to_string(datapack).unwrap();
-        let out: String;
-
-        if &transpiler_settings.output == &None {
-            out = String::from("databind-out.mcfunction");
-        } else {
-            out = transpiler_settings.output.as_ref().unwrap().clone();
-        }
-
-        let mut transpile = transpiler::Transpiler::new(content, &transpiler_settings, true);
-        let tokens = transpile.tokenize(false);
-        if tokens.contains(&token::Token::DefineFunc) {
-            println!("Cannot use functions in a lone file.");
-            std::process::exit(1);
-        }
-        let transpiled = transpile.transpile(tokens, None, None, false, false);
-
-        if let transpiler::TranspileReturn::SingleContents(contents) = transpiled {
-            fs::write(out, contents)?;
-        } else {
-            panic!("transpile() returned an incorrect enum");
-        }
+        println!("Databind does not support single-file compilation.");
+        std::process::exit(1);
     }
 
     Ok(())


### PR DESCRIPTION
Closes #19 

Removes support for single-file compilation and any mentions of it in the docs.