### PR TITLE
Remove unnecessary returns from transpile()

### DIFF
--- a/src/transpiler/mod.rs
+++ b/src/transpiler/mod.rs
@@ -16,22 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 use crate::settings::Settings;
-use std::collections::HashMap;
-
-/// Return from the transpiler
-///
-/// # Arguments
-///
-/// - `file_contents` - A list of file contents
-/// - `filename_map` - A map of filenames to indexes in the file_contents Vec
-/// - `var_map` - A map of variable names used in files to randomized names
-/// - `tag_map` - A map of tags to functions
-pub struct TranspileReturn {
-    pub file_contents: Vec<String>,
-    pub filename_map: HashMap<String, usize>,
-    pub var_map: HashMap<String, String>,
-    pub tag_map: HashMap<String, Vec<String>>,
-}
 
 pub struct Transpiler<'a> {
     chars: Vec<char>,

--- a/src/transpiler/mod.rs
+++ b/src/transpiler/mod.rs
@@ -18,49 +18,19 @@
 use crate::settings::Settings;
 use std::collections::HashMap;
 
-/// Returns from the transpiler
-pub enum TranspileReturn {
-    /// The contents of a single file
-    ///
-    /// # Arguments
-    ///
-    /// - `String` - The contents of the file
-    SingleContents(String),
-    /// The contents of a single file as well as a variable name map
-    ///
-    /// # Arguments
-    ///
-    /// - `String` - The contents of the file
-    /// - `HashMap<String, usize>` - A map of filenames to indexes
-    SingleContentsAndMap(String, HashMap<String, String>),
-    /// The contents of multiple files as well as a map of tags to functions
-    ///
-    /// # Arguments
-    ///
-    /// - `Vec<String>` - A list of file contents
-    /// - `HashMap<String, usize>` - A map of filenames to indexes
-    ///    The first key will always be `""`, which is the main file transpiled
-    /// - `HashMap<String, Vec<String>>` - A map of tags to functions
-    MultiFile(
-        Vec<String>,
-        HashMap<String, usize>,
-        HashMap<String, Vec<String>>,
-    ),
-    /// The contents of multiple files as well as a variable map and a map of tags to functions
-    ///
-    /// # Arguments
-    ///
-    /// - `Vec<String>` - A list of file contents
-    /// - `HashMap<String, usize>` - A map of filenames to indexes
-    ///    The first key will always be `""`, which is the main file transpiled
-    /// - `HashMap<String, String>` - A map of variable names used in files to randomized names
-    /// - `HashMap<String, Vec<String>>` - A map of tags to functions
-    MultiFileAndMap(
-        Vec<String>,
-        HashMap<String, usize>,
-        HashMap<String, String>,
-        HashMap<String, Vec<String>>,
-    ),
+/// Return from the transpiler
+///
+/// # Arguments
+///
+/// - `file_contents` - A list of file contents
+/// - `filename_map` - A map of filenames to indexes in the file_contents Vec
+/// - `var_map` - A map of variable names used in files to randomized names
+/// - `tag_map` - A map of tags to functions
+pub struct TranspileReturn {
+    pub file_contents: Vec<String>,
+    pub filename_map: HashMap<String, usize>,
+    pub var_map: HashMap<String, String>,
+    pub tag_map: HashMap<String, Vec<String>>,
 }
 
 pub struct Transpiler<'a> {

--- a/src/transpiler/transpile.rs
+++ b/src/transpiler/transpile.rs
@@ -29,15 +29,11 @@ impl Transpiler<'_> {
     /// - `tokens` - A list of tokens
     /// - `namespace` - The namespace to use for functions, if relevant
     /// - `existing_var_map` - An existing map of variables to randomized names
-    /// - `return_var_map` - Whether to return the var map used
-    /// - `return_multi_file` - Whether to return multiple files
     pub fn transpile(
         &self,
         tokens: Vec<Token>,
         namespace: Option<&str>,
         existing_var_map: Option<&HashMap<String, String>>,
-        return_var_map: bool,
-        return_multi_file: bool,
     ) -> TranspileReturn {
         let tokens = self.while_convert(tokens);
 
@@ -430,19 +426,17 @@ impl Transpiler<'_> {
             }
         }
 
-        // Remove leading/trailing whitespace from files
+        // Remove leading/trailing whitespace from files as well as empty lines
         for file in files.iter_mut() {
             *file = file.trim().to_string();
+            *file = file.replace("\n\n", "\n");
         }
 
-        if return_var_map && return_multi_file {
-            TranspileReturn::MultiFileAndMap(files, filename_to_index, var_map, tag_map)
-        } else if !return_var_map && !return_multi_file {
-            TranspileReturn::SingleContents(files[0].clone())
-        } else if return_var_map && !return_multi_file {
-            TranspileReturn::SingleContentsAndMap(files[0].clone(), var_map)
-        } else {
-            TranspileReturn::MultiFile(files, filename_to_index, tag_map)
+        TranspileReturn {
+            file_contents: files,
+            filename_map: filename_to_index,
+            var_map: var_map,
+            tag_map: tag_map,
         }
     }
 }

--- a/src/transpiler/transpile.rs
+++ b/src/transpiler/transpile.rs
@@ -15,11 +15,26 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use super::{TranspileReturn, Transpiler};
+use super::Transpiler;
 
 use crate::token::Token;
 use rand::{distributions::Alphanumeric, Rng};
 use std::collections::HashMap;
+
+/// Return from the transpiler
+///
+/// # Arguments
+///
+/// - `file_contents` - A list of file contents
+/// - `filename_map` - A map of filenames to indexes in the file_contents Vec
+/// - `var_map` - A map of variable names used in files to randomized names
+/// - `tag_map` - A map of tags to functions
+pub struct TranspileReturn {
+    pub file_contents: Vec<String>,
+    pub filename_map: HashMap<String, usize>,
+    pub var_map: HashMap<String, String>,
+    pub tag_map: HashMap<String, Vec<String>>,
+}
 
 impl Transpiler<'_> {
     /// Convert tokens to a transpiled file or files


### PR DESCRIPTION
Closes #24 

Replaces the `TranspileReturn` enum with a single struct.
