### PR TITLE
 Improve project creation/building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,15 +62,22 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "glob",
- "rand",
+ "rand 0.8.3",
  "regex",
  "same-file",
  "serde",
  "serde_derive",
  "serde_json",
+ "tempdir",
  "toml",
  "walkdir",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "getrandom"
@@ -142,13 +149,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.2",
  "rand_hc",
 ]
 
@@ -159,8 +179,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -177,7 +212,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -196,6 +240,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -255,6 +308,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 same-file = "1.0"
 regex = "1.5"
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,28 +19,28 @@ Using the CLI
 .. code-block:: text
 
    USAGE:
-      databind.exe [FLAGS] [OPTIONS] <DATAPACK>
-      databind.exe [FLAGS] [OPTIONS] <SUBCOMMAND>
+       databind [FLAGS] [OPTIONS] <DATAPACK>
+       databind [FLAGS] [OPTIONS] <SUBCOMMAND>
 
    FLAGS:
-      -h, --help                 Prints help information
-         --ignore-config        Ignore the config file. Used for testing
-         --random-var-names     Add characters to the end of variable names. Does not work when using variables across
-                                 multiple files
-         --var-display-names    Change the display name of variables in-game to hide extra characters. Only relevant with
-                                 --random-var-names
-      -V, --version              Prints version information
+       -h, --help                 Prints help information
+           --ignore-config        Ignore the config file. Used for testing
+           --random-var-names     Add characters to the end of variable names. Does not work when using variables across
+                                  multiple files
+           --var-display-names    Change the display name of variables in-game to hide extra characters. Only relevant with
+                                  --random-var-names
+       -V, --version              Prints version information
 
    OPTIONS:
-      -c, --config <config>    Configuration for the transpiler
-      -o, --out <output>       The output file or directory
+       -c, --config <config>    Configuration for the transpiler
+       -o, --out <output>       The output file or directory [default: out]
 
    ARGS:
-      <DATAPACK>    The Databind project to transpile
+       <DATAPACK>    The Databind project to transpile
 
    SUBCOMMANDS:
-      create    Create a new project
-      help      Prints this message or the help of the given subcommand(s)
+       create    Create a new project
+       help      Prints this message or the help of the given subcommand(s)
 
 From an Installation
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -4,9 +4,9 @@ Databind Configuration
 Configuration File
 ------------------
 
-Databind can be configured via a ``databind.toml`` file in the same
-directory as the binary is being run in. A config file can also
-be passed with the ``-c`` or ``--config`` option.
+Databind can be configured via the ``databind.toml`` generated
+in the project's root. A config file can also be passed
+with the ``-c`` or ``--config`` option.
 
 This table represents the default values of the options
 if no config changes are made.
@@ -23,9 +23,7 @@ if no config changes are made.
 +---------------------------------------+---------------------------------------------------------------------+
 | ``exclusions = []``                   | Specify what files not to copy over/transpile using globs           |
 +---------------------------------------+---------------------------------------------------------------------+
-|                                       | The output file or folder. If unspecified,                          |
-| ``output = String``                   | creates new folder ending in ``.databind`` or a file called         |
-|                                       | ``databind-out.mcfunction``                                         |
+| ``output = "out"``                    | The output file or folder                                           |
 +---------------------------------------+---------------------------------------------------------------------+
 
 Example Config
@@ -39,8 +37,7 @@ Below is a configuration file with all of the above settings.
    var_display_names = false
    inclusions = ["**/*.databind"]
    exclusions = []
-
-(The output option is omitted to use the default folder of ``project_name.databind``)
+   output = "out"
 
 CLI Arguments
 -------------
@@ -52,4 +49,4 @@ of ``random_var_names``) and may have different names or shorthand.
 
 Example use:
 
-``databind -c config.toml -o ./out ./datapack``
+``databind -c config.toml -o ./target ./datapack``

--- a/docs/examples/def_examples/long_execute.rst
+++ b/docs/examples/def_examples/long_execute.rst
@@ -6,7 +6,7 @@ Using definitions for a long execute command.
 Example
 -------
 
-``def_example/data/loop/functions/main.databind``
+``example/src/data/example/functions/main.databind``
 
 .. code-block:: databind
 
@@ -23,7 +23,7 @@ Example
 Transpiled
 ----------
 
-``def_example.databind/data/loop/functions/tick.mcfunction``
+``example/out/data/example/functions/tick.mcfunction``
 
 .. code-block:: mcfunction
 

--- a/docs/examples/function_examples/calling.rst
+++ b/docs/examples/function_examples/calling.rst
@@ -8,7 +8,7 @@ Different ways to call a function.
 
 Built into mcfunctions. Requires a namespace.
 
-``example/data/example/functions/main.databind``
+``example/src/data/example/functions/main.databind``
 
 .. code-block:: databind
 
@@ -24,7 +24,7 @@ Built into mcfunctions. Requires a namespace.
 Add namespaces to functions while transpiling.
 Allows more freedom with directory names.
 
-``example/data/example/functions/main.databind``
+``example/src/data/example/functions/main.databind``
 
 .. code-block:: databind
 
@@ -38,7 +38,7 @@ Transpiled, ``:call example_func`` becomes ``function example:example_func``.
 
 ``:call`` (explicit namespace)
 
-``example/data/example/functions/main.databind``
+``example/src/data/example/functions/main.databind``
 
 .. code-block:: databind
 

--- a/docs/examples/function_examples/simple_function.rst
+++ b/docs/examples/function_examples/simple_function.rst
@@ -6,7 +6,7 @@ Example
 
 A function that increments a counter and logs when it's run.
 
-``example/data/example/functions/main.databind``
+``example/src/data/example/functions/main.databind``
 
 .. code-block:: databind
 
@@ -23,14 +23,14 @@ A function that increments a counter and logs when it's run.
 Transpiled
 ----------
 
-``example.databind/data/example/functions/load.mcfunction``
+``example/out/data/example/functions/load.mcfunction``
 
 .. code-block:: mcfunction
 
    scoreboard objectives add counter dummy
    scoreboard players set --databind counter 0
 
-``example.databind/data/example/functions/example.mcfunction``
+``example/out/data/example/functions/example.mcfunction``
 
 .. code-block:: mcfunction
 

--- a/docs/examples/while_examples/for_loop.rst
+++ b/docs/examples/while_examples/for_loop.rst
@@ -6,7 +6,7 @@ A for loop-like while loop.
 Example
 -------
 
-``example/data/example/functions/main.databind``
+``example/src/data/example/functions/main.databind``
 
 .. code-block:: databind
 
@@ -27,7 +27,7 @@ When while loops are transpiled, functions with random characters
 at the end are created. In transpiled examples, these characters
 will be ``abcd``.
 
-``example.databind/data/example/functions/load.mcfunction``
+``example/out/data/example/functions/load.mcfunction``
 
 .. code-block:: mcfunction
 
@@ -36,13 +36,13 @@ will be ``abcd``.
    function example:while_abcd
    tellraw @a "Variable i is at 0"
 
-``example.databind/data/example/functions/while_abcd.mcfunction``
+``example/out/data/example/functions/while_abcd.mcfunction``
 
 .. code-block:: mcfunction
 
    execute if score --databind i matches 1.. run function example:condition_abcd
 
-``example.databind/data/example/functions/condition_abcd.mcfunction``
+``example/out/data/example/functions/condition_abcd.mcfunction``
 
 .. code-block:: mcfunction
 

--- a/docs/examples/while_examples/loop_until_false.rst
+++ b/docs/examples/while_examples/loop_until_false.rst
@@ -6,7 +6,7 @@ Use an integer as a boolean to loop until false.
 Example
 -------
 
-``example/data/example/functions/main.databind``
+``example/src/data/example/functions/main.databind``
 
 .. code-block:: databind
 
@@ -25,7 +25,7 @@ When while loops are transpiled, functions with random characters
 at the end are created. In transpiled examples, these characters
 will be ``abcd``.
 
-``example.databind/data/example/functions/load.mcfunction``
+``example/out/data/example/functions/load.mcfunction``
 
 .. code-block:: mcfunction
 
@@ -33,13 +33,13 @@ will be ``abcd``.
    scoreboard players set --databind bool 1
    function example:while_abcd
 
-``example.databind/data/example/functions/while_abcd.mcfunction``
+``example/out/data/example/functions/while_abcd.mcfunction``
 
 .. code-block:: mcfunction
 
    execute if score --databind bool matches 1 run function example:condition_abcd
 
-``example.databind/data/example/functions/condition_abcd.mcfunction``
+``example/out/data/example/functions/condition_abcd.mcfunction``
 
 .. code-block:: mcfunction
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -46,9 +46,8 @@ in the current directory. Only works if empty.
 Writing Code
 ------------
 
-By default, files named ``main.databind`` **can only be used** to define
-other functions, such as functions tagged with ``load`` or ``tick``.
-THe file contains this by default:
+Below is the default ``main.databind`` file. ``.databind`` files
+**can only be used** to contain function definitions.
 
 .. code-block:: databind
 
@@ -76,10 +75,9 @@ to give the function a load tag.
 Building
 --------
 
-To build your project, run ``databind <PATH>``. A folder with ``.databind``
-appended to the end will be generated. For example, if your project is
-in a folder called ``my_project`` then you should run ``databind my_project``,
-generating a folder called ``my_project.databind``.
+To build your project, run ``databind`` in the root directory of your project.
+Alternatively, you can run ``databind <PATH>`` where ``<PATH>`` is the path to
+your project.
 
 Additional Files
 ----------------

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@
 use clap::{App, Arg, SubCommand};
 
 /// Set up Clap CLI and get arguments
-pub fn get_cli_matches<'a>() -> clap::ArgMatches<'a> {
+pub fn get_app<'a, 'b>() -> App<'a, 'b> {
     App::new("Databind")
         .setting(clap::AppSettings::SubcommandsNegateReqs)
         .version("0.1.0")
@@ -91,5 +91,4 @@ pub fn get_cli_matches<'a>() -> clap::ArgMatches<'a> {
                         .value_name("PATH"),
                 ),
         )
-        .get_matches()
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,8 @@ pub fn get_cli_matches<'a>() -> clap::ArgMatches<'a> {
                 .short("o")
                 .long("out")
                 .help("The output file or directory")
-                .takes_value(true),
+                .takes_value(true)
+                .default_value("out"),
         )
         .arg(
             Arg::with_name("ignore-config")

--- a/src/create_project.rs
+++ b/src/create_project.rs
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+use crate::settings::Settings;
 use serde_derive::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -107,6 +108,12 @@ pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
     let pack_mcmeta = make_pack_mcmeta(description)?;
     path.push("pack.mcmeta");
     fs::write(&path, pack_mcmeta)?;
+
+    path.pop();
+    // Create databind.toml
+    let databind_toml = toml::to_string(&Settings::default()).unwrap();
+    path.push("databind.toml");
+    fs::write(&path, databind_toml)?;
 
     println!("Created project {} in {}", name, base_path);
     Ok(())

--- a/src/create_project.rs
+++ b/src/create_project.rs
@@ -68,9 +68,7 @@ pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
         name
     };
 
-    let mut path = PathBuf::new();
-    path.push("./");
-    path.push(base_path);
+    let mut path = PathBuf::from(format!("./{}", base_path));
 
     let metadata = fs::metadata(&path);
 
@@ -85,7 +83,7 @@ pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
         }
     }
 
-    path.push(format!("data/{}/functions", name));
+    path.push(format!("src/data/{}/functions", name));
     fs::create_dir_all(&path)?;
 
     // Create main.databind
@@ -110,6 +108,8 @@ pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
     fs::write(&path, pack_mcmeta)?;
 
     path.pop();
+    path.pop();
+
     // Create databind.toml
     let databind_toml = toml::to_string(&Settings::default()).unwrap();
     path.push("databind.toml");

--- a/src/create_project.rs
+++ b/src/create_project.rs
@@ -68,7 +68,7 @@ pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
         name
     };
 
-    let mut path = PathBuf::from(format!("./{}", base_path));
+    let mut path = PathBuf::from(base_path);
 
     let metadata = fs::metadata(&path);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#![warn(clippy::needless_borrow)]
+#![warn(clippy::redundant_clone)]
+
 use glob::glob;
 use same_file::is_same_file;
 use serde_derive::Serialize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,13 +114,13 @@ fn main() -> std::io::Result<()> {
         cli::get_app().get_matches_from(args)
     };
 
-    let datapack = matches.value_of("DATAPACK").unwrap();
-    let datapack_is_dir = fs::metadata(datapack)?.is_dir();
-
     // Check if create command is used
     if let Some(subcommand) = matches.subcommand {
         return create_project::create_project(subcommand.matches);
     }
+
+    let datapack = matches.value_of("DATAPACK").unwrap();
+    let datapack_is_dir = fs::metadata(datapack)?.is_dir();
 
     let config_path_str: String;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,6 @@ fn main() -> std::io::Result<()> {
     let matches = if args.len() > 1 {
         cli::get_app().get_matches()
     } else {
-        println!("WE HERE");
         let mut args: Vec<String> = vec!["databind".into()];
         // Find config file
         let cd = &env::current_dir().unwrap();
@@ -155,7 +154,6 @@ fn main() -> std::io::Result<()> {
         println!("{}", cli_out);
         if cli_out != "out" {
             transpiler_settings.output = cli_out.into();
-            println!("JOE?");
         }
     } else {
         transpiler_settings = settings::Settings::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,9 @@ fn merge_globs(globs: &Vec<String>, prefix: &str) -> Vec<PathBuf> {
 fn main() -> std::io::Result<()> {
     let matches = cli::get_cli_matches();
 
+    let datapack = matches.value_of("DATAPACK").unwrap();
+    let datapack_is_dir = fs::metadata(datapack)?.is_dir();
+
     // Check if create command is used
     if let Some(subcommand) = matches.subcommand {
         return create_project::create_project(subcommand.matches);
@@ -90,7 +93,13 @@ fn main() -> std::io::Result<()> {
             std::process::exit(1);
         }
     } else {
-        config_path_str = String::from("databind.toml");
+        // Look for databind.toml in target folder
+        let potential_path = format!("{}/databind.toml", datapack);
+        if fs::metadata(&potential_path).is_ok() {
+            config_path_str = potential_path;
+        } else {
+            config_path_str = String::new();
+        }
     }
 
     let config_path = Path::new(&config_path_str);
@@ -121,9 +130,6 @@ fn main() -> std::io::Result<()> {
     if matches.is_present("var-display-names") {
         transpiler_settings.var_display_names = true;
     }
-
-    let datapack = matches.value_of("DATAPACK").unwrap();
-    let datapack_is_dir = fs::metadata(datapack)?.is_dir();
 
     if datapack_is_dir {
         let mut var_map: HashMap<String, String> = HashMap::new();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,7 +26,7 @@ pub struct Settings {
     pub func_tag_inclusions: Vec<String>,
     pub inclusions: Vec<String>,
     pub exclusions: Vec<String>,
-    pub output: Option<String>,
+    pub output: String,
 }
 
 impl Default for Settings {
@@ -34,10 +34,10 @@ impl Default for Settings {
         Settings {
             random_var_names: false,
             var_display_names: false,
-            func_tag_inclusions: vec![String::from("tick"), String::from("load")],
-            inclusions: vec![String::from("**/*.databind")],
+            func_tag_inclusions: vec!["tick".into(), "load".into()],
+            inclusions: vec!["**/*.databind".into()],
             exclusions: Vec::new(),
-            output: None,
+            output: "out".into(),
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,7 +23,6 @@ use serde_derive::{Deserialize, Serialize};
 pub struct Settings {
     pub random_var_names: bool,
     pub var_display_names: bool,
-    pub func_tag_inclusions: Vec<String>,
     pub inclusions: Vec<String>,
     pub exclusions: Vec<String>,
     pub output: String,
@@ -34,7 +33,6 @@ impl Default for Settings {
         Settings {
             random_var_names: false,
             var_display_names: false,
-            func_tag_inclusions: vec!["tick".into(), "load".into()],
             inclusions: vec!["**/*.databind".into()],
             exclusions: Vec::new(),
             output: "out".into(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,10 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use serde_derive::Deserialize;
+use serde_derive::{Deserialize, Serialize};
 
 /// Settings for the transpiler
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
     pub random_var_names: bool,

--- a/src/transpiler/mod.rs
+++ b/src/transpiler/mod.rs
@@ -49,7 +49,7 @@ impl Transpiler<'_> {
             chars: text.chars().collect(),
             position: 0,
             current_char: first_char,
-            settings: &settings,
+            settings: settings,
         }
     }
 

--- a/src/transpiler/preprocess.rs
+++ b/src/transpiler/preprocess.rs
@@ -33,7 +33,7 @@ impl Transpiler<'_> {
     pub fn replace_definitions(contents: &str) -> String {
         let settings = &Settings::default();
         let mut transpiler = Transpiler::new(contents.to_string(), settings, false);
-        let mut new_contents = contents.clone();
+        let mut new_contents = &*contents.to_string();
 
         let replacement_tokens = transpiler.tokenize(true);
 
@@ -46,7 +46,7 @@ impl Transpiler<'_> {
                 Token::ReplaceContents(contents) => {
                     replacement_map
                         .entry(current_name.to_owned())
-                        .or_insert(contents.clone());
+                        .or_insert_with(|| contents.clone());
                 }
                 _ => {}
             }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -34,20 +34,22 @@ fn test_config() {
             path_str,
             "--config",
             &format!("{}/databind.toml", path_str)[..],
+            "--out",
+            &format!("{}/../out", path_str),
         ],
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
     path.pop();
 
-    path.push("test_config.databind/data/test/functions");
+    path.push("out/data/test/functions");
     tests::check_files_exist(&path, &expected_funcs, "test_config:");
     path.pop();
     path.pop();
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("test_config.databind");
+    out_path.push("out");
     fs::remove_dir_all(out_path).unwrap();
 }
 
@@ -65,6 +67,8 @@ fn test_no_config_out() {
             path_str,
             "--config",
             &format!("{}/should_not_be_made.toml", path_str)[..],
+            "--out",
+            &format!("{}/../out", path_str),
         ],
     );
 
@@ -73,7 +77,7 @@ fn test_no_config_out() {
     let unexpected_toml = ["should_not_be_made.toml"];
 
     path.pop();
-    path.push("test_no_config_out.databind/data/test/functions");
+    path.push("out/data/test/functions");
     tests::check_files_exist(&path, &expected_funcs, "test_no_config_out:");
     path.pop();
     path.pop();
@@ -87,6 +91,6 @@ fn test_no_config_out() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("test_no_config_out.databind");
+    out_path.push("out");
     fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -35,12 +35,11 @@ fn test_config() {
             "--config",
             &format!("{}/databind.toml", path_str)[..],
             "--out",
-            &format!("{}/../out", path_str),
+            &format!("{}/out", path_str),
         ],
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
-    path.pop();
 
     path.push("out/data/test/functions");
     tests::check_files_exist(&path, &expected_funcs, "test_config:");
@@ -49,7 +48,7 @@ fn test_config() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("out");
+    out_path.push("test_config/out");
     fs::remove_dir_all(out_path).unwrap();
 }
 
@@ -68,7 +67,7 @@ fn test_no_config_out() {
             "--config",
             &format!("{}/should_not_be_made.toml", path_str)[..],
             "--out",
-            &format!("{}/../out", path_str),
+            &format!("{}/out", path_str),
         ],
     );
 
@@ -76,7 +75,6 @@ fn test_no_config_out() {
     let expected_toml = ["should_be_made.toml"];
     let unexpected_toml = ["should_not_be_made.toml"];
 
-    path.pop();
     path.push("out/data/test/functions");
     tests::check_files_exist(&path, &expected_funcs, "test_no_config_out:");
     path.pop();
@@ -91,6 +89,6 @@ fn test_no_config_out() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("out");
+    out_path.push("test_no_config_out/out");
     fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use std::fs;
+use tempdir::TempDir;
 
 mod tests;
 
@@ -26,6 +26,8 @@ fn test_config() {
     path.push("test_config");
     let path_str = path.to_str().unwrap();
 
+    let out = TempDir::new("test_config").expect("Could not create tempdir for test");
+
     tests::run_with_args(
         "cargo",
         &[
@@ -35,21 +37,16 @@ fn test_config() {
             "--config",
             &format!("{}/databind.toml", path_str)[..],
             "--out",
-            &format!("{}/out", path_str),
+            out.path().to_str().unwrap(),
         ],
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
 
-    path.push("out/data/test/functions");
+    path.push(format!("{}/data/test/functions", out.path().display()));
     tests::check_files_exist(&path, &expected_funcs, "test_config:");
     path.pop();
     path.pop();
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_config/out");
-    fs::remove_dir_all(out_path).unwrap();
 }
 
 #[test]
@@ -57,6 +54,8 @@ fn test_no_config_out() {
     let mut path = tests::resources();
     path.push("test_no_config_out");
     let path_str = path.to_str().unwrap();
+
+    let out = TempDir::new("test_no_config_out").expect("Could not create tempdir for test");
 
     tests::run_with_args(
         "cargo",
@@ -67,7 +66,7 @@ fn test_no_config_out() {
             "--config",
             &format!("{}/should_not_be_made.toml", path_str)[..],
             "--out",
-            &format!("{}/out", path_str),
+            out.path().to_str().unwrap(),
         ],
     );
 
@@ -75,7 +74,7 @@ fn test_no_config_out() {
     let expected_toml = ["should_be_made.toml"];
     let unexpected_toml = ["should_not_be_made.toml"];
 
-    path.push("out/data/test/functions");
+    path.push(format!("{}/data/test/functions", out.path().display()));
     tests::check_files_exist(&path, &expected_funcs, "test_no_config_out:");
     path.pop();
     path.pop();
@@ -86,9 +85,4 @@ fn test_no_config_out() {
 
     // Ensure config toml file is not outputted
     tests::check_files_dont_exist(&path, &unexpected_toml, "test_no_config_out");
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_no_config_out/out");
-    fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -39,6 +39,7 @@ fn test_config() {
             "--out",
             out.path().to_str().unwrap(),
         ],
+        None,
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
@@ -68,6 +69,7 @@ fn test_no_config_out() {
             "--out",
             out.path().to_str().unwrap(),
         ],
+        None,
     );
 
     let expected_funcs = ["tick.mcfunction"];

--- a/tests/create_tests.rs
+++ b/tests/create_tests.rs
@@ -15,16 +15,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use std::fs;
+use std::path::PathBuf;
+use tempdir::TempDir;
 
 mod tests;
 
 /// Test that the TOML config is properly followed
 #[test]
 fn test_create_structure() {
-    let mut path = tests::resources();
-    path.push("test_create_structure");
-    let path_str = path.to_str().unwrap();
+    let out = TempDir::new("test_create_structure").expect("Could not create tempdir for test");
+    let mut path = PathBuf::from(out.path());
 
     tests::run_with_args(
         "cargo",
@@ -34,12 +34,9 @@ fn test_create_structure() {
             "create",
             "test_create_structure",
             "--path",
-            path_str,
+            out.path().to_str().unwrap(),
         ],
     );
-
-    println!("alleged path: {}", path.display());
-
     // Check that the folder was created
     assert!(path.exists() && path.is_dir());
 
@@ -56,9 +53,4 @@ fn test_create_structure() {
     // Check that the main.databind file was created
     path.push("data/test_create_structure/functions/main.databind");
     assert!(path.exists() && path.is_file());
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_create_structure");
-    fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/create_tests.rs
+++ b/tests/create_tests.rs
@@ -1,0 +1,64 @@
+/*
+ * Databind - Expand the functionality of Minecraft Datapacks.
+ * Copyright (C) 2021  Adam Thompson-Sharpe
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+use std::fs;
+
+mod tests;
+
+/// Test that the TOML config is properly followed
+#[test]
+fn test_create_structure() {
+    let mut path = tests::resources();
+    path.push("test_create_structure");
+    let path_str = path.to_str().unwrap();
+
+    tests::run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--",
+            "create",
+            "test_create_structure",
+            "--path",
+            path_str,
+        ],
+    );
+
+    println!("alleged path: {}", path.display());
+
+    // Check that the folder was created
+    assert!(path.exists() && path.is_dir());
+
+    // Check that the config file was created
+    path.push("databind.toml");
+    assert!(path.exists() && path.is_file());
+    path.pop();
+
+    // Check that the pack.mcmeta file was created
+    path.push("src/pack.mcmeta");
+    assert!(path.exists() && path.is_file());
+    path.pop();
+
+    // Check that the main.databind file was created
+    path.push("data/test_create_structure/functions/main.databind");
+    assert!(path.exists() && path.is_file());
+
+    // Delete generated folder
+    let mut out_path = tests::resources();
+    out_path.push("test_create_structure");
+    fs::remove_dir_all(out_path).unwrap();
+}

--- a/tests/create_tests.rs
+++ b/tests/create_tests.rs
@@ -20,7 +20,7 @@ use tempdir::TempDir;
 
 mod tests;
 
-/// Test that the TOML config is properly followed
+/// Test the `databind create` file structure
 #[test]
 fn test_create_structure() {
     let out = TempDir::new("test_create_structure").expect("Could not create tempdir for test");
@@ -36,6 +36,7 @@ fn test_create_structure() {
             "--path",
             out.path().to_str().unwrap(),
         ],
+        None,
     );
     // Check that the folder was created
     assert!(path.exists() && path.is_dir());
@@ -53,4 +54,42 @@ fn test_create_structure() {
     // Check that the main.databind file was created
     path.push("data/test_create_structure/functions/main.databind");
     assert!(path.exists() && path.is_file());
+}
+
+/// Test running `databind` alone in a created project
+#[test]
+fn test_databind_alone() {
+    let out = TempDir::new("test_databind_alone").expect("Could not create tempdir for test");
+    let mut path = PathBuf::from(out.path());
+
+    // Create project
+    tests::run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--",
+            "create",
+            "test_databind_alone",
+            "--path",
+            out.path().to_str().unwrap(),
+        ],
+        None,
+    );
+
+    // Run `databind` in directory
+
+    tests::run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--manifest-path",
+            &format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"))[..],
+        ],
+        Some(&path),
+    );
+
+    // Test that out directory exists
+    path.push("out");
+    println!("Checking path {}", path.display());
+    assert!(path.exists() && path.is_dir());
 }

--- a/tests/func_tests.rs
+++ b/tests/func_tests.rs
@@ -28,7 +28,17 @@ fn test_file_structure() {
     path.push("test_file_structure");
     let path_str = path.to_str().unwrap();
 
-    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
+    tests::run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--",
+            path_str,
+            "--ignore-config",
+            "--out",
+            &format!("{}/../out", path_str),
+        ],
+    );
 
     let expected_funcs = [
         "load.mcfunction",
@@ -40,7 +50,7 @@ fn test_file_structure() {
     let unexpected_tags = ["main.json", "first_func.json", "second_func.json"];
 
     path.pop();
-    path.push("test_file_structure.databind/data");
+    path.push("out/data");
 
     // Check if function files are correctly placed
     path.push("test/functions");
@@ -57,7 +67,7 @@ fn test_file_structure() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("test_file_structure.databind");
+    out_path.push("out");
     fs::remove_dir_all(out_path).unwrap();
 }
 
@@ -68,12 +78,22 @@ fn test_nested_funcs() {
     path.push("test_nested_funcs");
     let path_str = path.to_str().unwrap();
 
-    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
+    tests::run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--",
+            path_str,
+            "--ignore-config",
+            "--out",
+            &format!("{}/../out", path_str),
+        ],
+    );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
 
     path.pop();
-    path.push("test_nested_funcs.databind/data");
+    path.push("out/data");
 
     // Check if function files are correctly placed
     path.push("test/functions");
@@ -83,6 +103,6 @@ fn test_nested_funcs() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("test_nested_funcs.databind");
+    out_path.push("out");
     fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/func_tests.rs
+++ b/tests/func_tests.rs
@@ -39,6 +39,7 @@ fn test_file_structure() {
             "--out",
             out.path().to_str().unwrap(),
         ],
+        None,
     );
 
     let expected_funcs = [
@@ -82,6 +83,7 @@ fn test_nested_funcs() {
             "--out",
             out.path().to_str().unwrap(),
         ],
+        None,
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];

--- a/tests/func_tests.rs
+++ b/tests/func_tests.rs
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use std::fs;
+use tempdir::TempDir;
 
 mod tests;
 
@@ -26,17 +26,18 @@ mod tests;
 fn test_file_structure() {
     let mut path = tests::resources();
     path.push("test_file_structure");
-    let path_str = path.to_str().unwrap();
+
+    let out = TempDir::new("test_file_structure").expect("Could not create tempdir for test");
 
     tests::run_with_args(
         "cargo",
         &[
             "run",
             "--",
-            path_str,
+            path.to_str().unwrap(),
             "--ignore-config",
             "--out",
-            &format!("{}/out", path_str),
+            out.path().to_str().unwrap(),
         ],
     );
 
@@ -49,10 +50,8 @@ fn test_file_structure() {
     let expected_tags = ["load.json", "tick.json"];
     let unexpected_tags = ["main.json", "first_func.json", "second_func.json"];
 
-    path.push("out/data");
-
     // Check if function files are correctly placed
-    path.push("test/functions");
+    path.push(format!("{}/data/test/functions", out.path().display()));
     tests::check_files_exist(&path, &expected_funcs, "test_file_structure");
     path.pop();
     path.pop();
@@ -63,11 +62,6 @@ fn test_file_structure() {
 
     // Ensure unexpected tag files do not exist
     tests::check_files_dont_exist(&path, &unexpected_tags, "test_file_structure");
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_file_structure/out");
-    fs::remove_dir_all(out_path).unwrap();
 }
 
 /// Test that nested functions are properly generated
@@ -75,32 +69,26 @@ fn test_file_structure() {
 fn test_nested_funcs() {
     let mut path = tests::resources();
     path.push("test_nested_funcs");
-    let path_str = path.to_str().unwrap();
+
+    let out = TempDir::new("test_nested_funcs").expect("Could not create tempdir for test");
 
     tests::run_with_args(
         "cargo",
         &[
             "run",
             "--",
-            path_str,
+            path.to_str().unwrap(),
             "--ignore-config",
             "--out",
-            &format!("{}/out", path_str),
+            out.path().to_str().unwrap(),
         ],
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
 
-    path.push("out/data");
-
     // Check if function files are correctly placed
-    path.push("test/functions");
+    path.push(format!("{}/data/test/functions", out.path().display()));
     tests::check_files_exist(&path, &expected_funcs, "test_nested_funcs");
     path.pop();
     path.pop();
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_nested_funcs/out");
-    fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/func_tests.rs
+++ b/tests/func_tests.rs
@@ -36,7 +36,7 @@ fn test_file_structure() {
             path_str,
             "--ignore-config",
             "--out",
-            &format!("{}/../out", path_str),
+            &format!("{}/out", path_str),
         ],
     );
 
@@ -49,7 +49,6 @@ fn test_file_structure() {
     let expected_tags = ["load.json", "tick.json"];
     let unexpected_tags = ["main.json", "first_func.json", "second_func.json"];
 
-    path.pop();
     path.push("out/data");
 
     // Check if function files are correctly placed
@@ -67,7 +66,7 @@ fn test_file_structure() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("out");
+    out_path.push("test_file_structure/out");
     fs::remove_dir_all(out_path).unwrap();
 }
 
@@ -86,13 +85,12 @@ fn test_nested_funcs() {
             path_str,
             "--ignore-config",
             "--out",
-            &format!("{}/../out", path_str),
+            &format!("{}/out", path_str),
         ],
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
 
-    path.pop();
     path.push("out/data");
 
     // Check if function files are correctly placed
@@ -103,6 +101,6 @@ fn test_nested_funcs() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("out");
+    out_path.push("test_nested_funcs/out");
     fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use std::fs;
+use tempdir::TempDir;
 
 mod tests;
 
@@ -24,17 +24,18 @@ mod tests;
 fn test_tag_generation() {
     let mut path = tests::resources();
     path.push("test_tag_generation");
-    let path_str = path.to_str().unwrap();
+
+    let out = TempDir::new("test_tag_generation").expect("Could not create tempdir for test");
 
     tests::run_with_args(
         "cargo",
         &[
             "run",
             "--",
-            path_str,
+            path.to_str().unwrap(),
             "--ignore-config",
             "--out",
-            &format!("{}/out", path_str),
+            out.path().to_str().unwrap(),
         ],
     );
 
@@ -42,10 +43,8 @@ fn test_tag_generation() {
     let expected_tags = ["load.json", "tick.json", "second_tag.json", "func3.json"];
     let unexpected_tags = ["main.json"];
 
-    path.push("out/data");
-
     // Check if function files are correctly placed
-    path.push("test/functions");
+    path.push(format!("{}/data/test/functions", out.path().display()));
     tests::check_files_exist(&path, &expected_funcs, "test_tag_generation");
     path.pop();
     path.pop();
@@ -56,11 +55,6 @@ fn test_tag_generation() {
 
     // Ensure unexpected tag files do not exist
     tests::check_files_dont_exist(&path, &unexpected_tags, "test_tag_generation");
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_tag_generation/out");
-    fs::remove_dir_all(out_path).unwrap();
 }
 
 /// Test multiple ways to format :tag code
@@ -68,19 +62,18 @@ fn test_tag_generation() {
 fn test_tag_syntax() {
     let mut path = tests::resources();
     path.push("test_tag_syntax");
-    let path_str = path.to_str().unwrap();
 
-    println!("outputting @ {}/{}", path_str, "out");
+    let out = TempDir::new("test_tag_syntax").expect("Could not create tempdir for test");
 
     tests::run_with_args(
         "cargo",
         &[
             "run",
             "--",
-            path_str,
+            path.to_str().unwrap(),
             "--ignore-config",
             "--out",
-            &format!("{}/out", path_str),
+            out.path().to_str().unwrap(),
         ],
     );
 
@@ -93,10 +86,8 @@ fn test_tag_syntax() {
     ];
     let unexpected_tags = ["main.json"];
 
-    path.push("out/data");
-
     // Check if function files are correctly placed
-    path.push("test/functions");
+    path.push(format!("{}/data/test/functions", out.path().display()));
     tests::check_files_exist(&path, &expected_funcs, "test_tag_syntax");
     path.pop();
     path.pop();
@@ -107,9 +98,4 @@ fn test_tag_syntax() {
 
     // Ensure unexpected tag files do not exist
     tests::check_files_dont_exist(&path, &unexpected_tags, "test_tag_syntax");
-
-    // Delete generated folder
-    let mut out_path = tests::resources();
-    out_path.push("test_tag_syntax/out");
-    fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -37,6 +37,7 @@ fn test_tag_generation() {
             "--out",
             out.path().to_str().unwrap(),
         ],
+        None,
     );
 
     let expected_funcs = ["load.mcfunction", "tick.mcfunction", "func3.mcfunction"];
@@ -75,6 +76,7 @@ fn test_tag_syntax() {
             "--out",
             out.path().to_str().unwrap(),
         ],
+        None,
     );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -26,14 +26,24 @@ fn test_tag_generation() {
     path.push("test_tag_generation");
     let path_str = path.to_str().unwrap();
 
-    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
+    tests::run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--",
+            path_str,
+            "--ignore-config",
+            "--out",
+            &format!("{}/../out", path_str),
+        ],
+    );
 
     let expected_funcs = ["load.mcfunction", "tick.mcfunction", "func3.mcfunction"];
     let expected_tags = ["load.json", "tick.json", "second_tag.json", "func3.json"];
     let unexpected_tags = ["main.json"];
 
     path.pop();
-    path.push("test_tag_generation.databind/data");
+    path.push("out/data");
 
     // Check if function files are correctly placed
     path.push("test/functions");
@@ -50,7 +60,7 @@ fn test_tag_generation() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("test_tag_generation.databind");
+    out_path.push("out");
     fs::remove_dir_all(out_path).unwrap();
 }
 
@@ -61,7 +71,19 @@ fn test_tag_syntax() {
     path.push("test_tag_syntax");
     let path_str = path.to_str().unwrap();
 
-    tests::run_with_args("cargo", &["run", "--", path_str, "--ignore-config"]);
+    println!("outputting @ {}/{}", path_str, "out");
+
+    tests::run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--",
+            path_str,
+            "--ignore-config",
+            "--out",
+            &format!("{}/../out", path_str),
+        ],
+    );
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
     let expected_tags = [
@@ -73,7 +95,7 @@ fn test_tag_syntax() {
     let unexpected_tags = ["main.json"];
 
     path.pop();
-    path.push("test_tag_syntax.databind/data");
+    path.push("out/data");
 
     // Check if function files are correctly placed
     path.push("test/functions");
@@ -90,6 +112,6 @@ fn test_tag_syntax() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("test_tag_syntax.databind");
+    out_path.push("out");
     fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -34,7 +34,7 @@ fn test_tag_generation() {
             path_str,
             "--ignore-config",
             "--out",
-            &format!("{}/../out", path_str),
+            &format!("{}/out", path_str),
         ],
     );
 
@@ -42,7 +42,6 @@ fn test_tag_generation() {
     let expected_tags = ["load.json", "tick.json", "second_tag.json", "func3.json"];
     let unexpected_tags = ["main.json"];
 
-    path.pop();
     path.push("out/data");
 
     // Check if function files are correctly placed
@@ -60,7 +59,7 @@ fn test_tag_generation() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("out");
+    out_path.push("test_tag_generation/out");
     fs::remove_dir_all(out_path).unwrap();
 }
 
@@ -81,7 +80,7 @@ fn test_tag_syntax() {
             path_str,
             "--ignore-config",
             "--out",
-            &format!("{}/../out", path_str),
+            &format!("{}/out", path_str),
         ],
     );
 
@@ -94,7 +93,6 @@ fn test_tag_syntax() {
     ];
     let unexpected_tags = ["main.json"];
 
-    path.pop();
     path.push("out/data");
 
     // Check if function files are correctly placed
@@ -112,6 +110,6 @@ fn test_tag_syntax() {
 
     // Delete generated folder
     let mut out_path = tests::resources();
-    out_path.push("out");
+    out_path.push("test_tag_syntax/out");
     fs::remove_dir_all(out_path).unwrap();
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -32,7 +32,7 @@ pub fn run_with_args(cmd: &str, args: &[&str]) -> String {
 
 pub fn resources() -> PathBuf {
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    d.push("tests\\resources");
+    d.push("tests/resources");
     d
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -32,7 +32,7 @@ pub fn run_with_args(cmd: &str, args: &[&str]) -> String {
 
 pub fn resources() -> PathBuf {
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    d.push("tests/resources");
+    d.push("tests\\resources");
     d
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,17 +17,21 @@
  */
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 
-pub fn run_with_args(cmd: &str, args: &[&str]) -> String {
-    String::from_utf8(
+pub fn run_with_args(cmd: &str, args: &[&str], path: Option<&dyn AsRef<Path>>) -> Output {
+    if let Some(p) = path {
+        Command::new(cmd)
+            .args(args)
+            .current_dir(p.as_ref())
+            .output()
+            .expect("Failed to execute process")
+    } else {
         Command::new(cmd)
             .args(args)
             .output()
             .expect("Failed to execute process")
-            .stdout,
-    )
-    .unwrap()
+    }
 }
 
 pub fn resources() -> PathBuf {


### PR DESCRIPTION
Closes #22

- [x] Make `databind create` generate a `databind.toml` with default settings
- [x] Make `databind create` generate the file structure described in #22
- [x] Replace `<project_name>.databind` as the default output folder with `out` or something similar
- [x] Allow `databind` alone to be run in a project and detect the config file
   - [x] Find `databind.toml` file no matter the current directory in the project
- [x] Write tests for everything
- [x] Update docs