### PR TITLE
Replace "transpile" with "compile" throughout project

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,10 +1,10 @@
 Databind CLI
 ============
 
-What Can Be Transpiled
+What Can Be Compiled
 ----------------------
 
-Databind transpiles Databind projects (see :ref:`Creating a Project`).
+Databind compiles Databind projects (see :ref:`Creating a Project`).
 Databind will look for included files (``**/*.databind`` by default) and
 leave other files alone.
 
@@ -32,11 +32,11 @@ Using the CLI
        -V, --version              Prints version information
 
    OPTIONS:
-       -c, --config <config>    Configuration for the transpiler
+       -c, --config <config>    Configuration for the compiler
        -o, --out <output>       The output file or directory [default: out]
 
    ARGS:
-       <DATAPACK>    The Databind project to transpile
+       <DATAPACK>    The Databind project to compile
 
    SUBCOMMANDS:
        create    Create a new project

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -19,9 +19,9 @@ if no config changes are made.
 +---------------------------------------+---------------------------------------------------------------------+
 | ``var_display_names = false``         | Whether to update scoreboard display names for randomized variables |
 +---------------------------------------+---------------------------------------------------------------------+
-| ``inclusions = ["**/*.databind"]``    | Specify what files to transpile using globs                         |
+| ``inclusions = ["**/*.databind"]``    | Specify what files to compile using globs                           |
 +---------------------------------------+---------------------------------------------------------------------+
-| ``exclusions = []``                   | Specify what files not to copy over/transpile using globs           |
+| ``exclusions = []``                   | Specify what files not to copy over/compile using globs             |
 +---------------------------------------+---------------------------------------------------------------------+
 | ``output = "out"``                    | The output file or folder                                           |
 +---------------------------------------+---------------------------------------------------------------------+

--- a/docs/examples/def_examples/long_execute.rst
+++ b/docs/examples/def_examples/long_execute.rst
@@ -20,8 +20,8 @@ Example
    LONG_EXECUTE run summon lightning_bolt ^-5 ^ ^
    :endfunc
 
-Transpiled
-----------
+Compiled
+--------
 
 ``example/out/data/example/functions/tick.mcfunction``
 

--- a/docs/examples/function_examples/calling.rst
+++ b/docs/examples/function_examples/calling.rst
@@ -21,7 +21,7 @@ Built into mcfunctions. Requires a namespace.
 ``:call`` (infer namespace)
 ---------------------------
 
-Add namespaces to functions while transpiling.
+Add namespaces to functions while compiling.
 Allows more freedom with directory names.
 
 ``example/src/data/example/functions/main.databind``

--- a/docs/examples/function_examples/calling.rst
+++ b/docs/examples/function_examples/calling.rst
@@ -34,7 +34,7 @@ Allows more freedom with directory names.
 
    :call example_func
 
-Transpiled, ``:call example_func`` becomes ``function example:example_func``.
+Compiled, ``:call example_func`` becomes ``function example:example_func``.
 
 ``:call`` (explicit namespace)
 

--- a/docs/examples/function_examples/simple_function.rst
+++ b/docs/examples/function_examples/simple_function.rst
@@ -20,8 +20,8 @@ A function that increments a counter and logs when it's run.
    :var counter += 1
    :endfunc
 
-Transpiled
-----------
+Compiled
+--------
 
 ``example/out/data/example/functions/load.mcfunction``
 

--- a/docs/examples/objective_examples/create_objective.rst
+++ b/docs/examples/objective_examples/create_objective.rst
@@ -12,8 +12,8 @@ Example
    :obj points dummy
    :sobj points @a = 100
 
-Transpiled
-----------
+Compiled
+--------
 
 .. code-block:: mcfunction
 

--- a/docs/examples/variable_examples/create_modify_test.rst
+++ b/docs/examples/variable_examples/create_modify_test.rst
@@ -17,8 +17,8 @@ Example
    # Say something if example is 1
    execute if :tvar example matches 1 run say Variable example is equal to 1!
 
-Transpiled
-----------
+Compiled
+--------
 
 .. code-block:: mcfunction
 

--- a/docs/examples/while_examples/for_loop.rst
+++ b/docs/examples/while_examples/for_loop.rst
@@ -20,11 +20,11 @@ Example
    tellraw @a "Variable i is at 0"
    :endfunc
 
-Transpiled
-----------
+Compiled
+--------
 
-When while loops are transpiled, functions with random characters
-at the end are created. In transpiled examples, these characters
+When while loops are compiled, functions with random characters
+at the end are created. In compiled examples, these characters
 will be ``abcd``.
 
 ``example/out/data/example/functions/load.mcfunction``

--- a/docs/examples/while_examples/loop_until_false.rst
+++ b/docs/examples/while_examples/loop_until_false.rst
@@ -18,11 +18,11 @@ Example
    :endwhile
    :endfunc
    
-Transpiled
-----------
+Compiled
+--------
 
-When while loops are transpiled, functions with random characters
-at the end are created. In transpiled examples, these characters
+When while loops are compiled, functions with random characters
+at the end are created. In compiled examples, these characters
 will be ``abcd``.
 
 ``example/out/data/example/functions/load.mcfunction``

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,14 +26,14 @@ pub fn get_app<'a, 'b>() -> App<'a, 'b> {
         .about("Expand the functionality of Minecraft Datapacks.")
         .arg(
             Arg::with_name("DATAPACK")
-                .help("The Databind project to transpile")
+                .help("The Databind project to compile")
                 .required(true),
         )
         .arg(
             Arg::with_name("config")
                 .short("c")
                 .long("config")
-                .help("Configuration for the transpiler")
+                .help("Configuration for the compiler")
                 .takes_value(true),
         )
         .arg(

--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -15,13 +15,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use super::Transpiler;
+use super::Compiler;
 
 use crate::token::Token;
 use rand::{distributions::Alphanumeric, Rng};
 use std::collections::HashMap;
 
-/// Return from the transpiler
+/// Return from the compiler
 ///
 /// # Arguments
 ///
@@ -29,27 +29,27 @@ use std::collections::HashMap;
 /// - `filename_map` - A map of filenames to indexes in the file_contents Vec
 /// - `var_map` - A map of variable names used in files to randomized names
 /// - `tag_map` - A map of tags to functions
-pub struct TranspileReturn {
+pub struct CompileReturn {
     pub file_contents: Vec<String>,
     pub filename_map: HashMap<String, usize>,
     pub var_map: HashMap<String, String>,
     pub tag_map: HashMap<String, Vec<String>>,
 }
 
-impl Transpiler<'_> {
-    /// Convert tokens to a transpiled file or files
+impl Compiler<'_> {
+    /// Convert tokens to a compiled file or files
     ///
     /// # Arguments
     ///
     /// - `tokens` - A list of tokens
     /// - `namespace` - The namespace to use for functions, if relevant
     /// - `existing_var_map` - An existing map of variables to randomized names
-    pub fn transpile(
+    pub fn compile(
         &self,
         tokens: Vec<Token>,
         namespace: Option<&str>,
         existing_var_map: Option<&HashMap<String, String>>,
-    ) -> TranspileReturn {
+    ) -> CompileReturn {
         let tokens = self.while_convert(tokens);
 
         let mut var_map: HashMap<String, String>;
@@ -80,7 +80,7 @@ impl Transpiler<'_> {
         let mut objective_target = String::new();
 
         for token in tokens.iter() {
-            // Don't transpile contents outside of a function
+            // Don't compile contents outside of a function
             match token {
                 Token::DefineFunc => {}
                 _ => {
@@ -454,7 +454,7 @@ impl Transpiler<'_> {
             *file = file.replace("\n\n", "\n");
         }
 
-        TranspileReturn {
+        CompileReturn {
             file_contents: files,
             filename_map: filename_to_index,
             var_map,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -17,24 +17,24 @@
  */
 use crate::settings::Settings;
 
-pub struct Transpiler<'a> {
+pub struct Compiler<'a> {
     chars: Vec<char>,
     position: usize,
     current_char: char,
     settings: &'a Settings,
 }
 
-impl Transpiler<'_> {
-    /// Create a new Transpiler.
+impl Compiler<'_> {
+    /// Create a new Compiler.
     ///
     /// # Arguments
     ///
-    /// - `text` - The contents of the file to transpile
-    /// - `settings` - The settings for the transpiler
+    /// - `text` - The contents of the file to compile
+    /// - `settings` - The settings for the compiler
     /// - `replacement` - Whether to replace :def's. Required to avoid stack overflow
-    pub fn new(text: String, settings: &Settings, replacement: bool) -> Transpiler<'_> {
+    pub fn new(text: String, settings: &Settings, replacement: bool) -> Compiler<'_> {
         let text = if replacement {
-            Transpiler::replace_definitions(&text)
+            Compiler::replace_definitions(&text)
         } else {
             text
         };
@@ -45,7 +45,7 @@ impl Transpiler<'_> {
             '\u{0}'
         };
 
-        Transpiler {
+        Compiler {
             chars: text.chars().collect(),
             position: 0,
             current_char: first_char,
@@ -64,6 +64,6 @@ impl Transpiler<'_> {
     }
 }
 
+mod compile;
 mod preprocess;
 mod tokenize;
-mod transpile;

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -15,14 +15,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use super::Transpiler;
+use super::Compiler;
 use crate::settings::Settings;
 use crate::token::Token;
 use rand::{distributions::Alphanumeric, Rng};
 use regex::Regex;
 use std::collections::HashMap;
 
-impl Transpiler<'_> {
+impl Compiler<'_> {
     /// Get text replacement definitions and replace matches.
     /// Definitions that are not at the top of the file will be ignored
     /// and cause errors
@@ -32,10 +32,10 @@ impl Transpiler<'_> {
     /// - `content` - The contents of a file
     pub fn replace_definitions(contents: &str) -> String {
         let settings = &Settings::default();
-        let mut transpiler = Transpiler::new(contents.to_string(), settings, false);
+        let mut compiler = Compiler::new(contents.to_string(), settings, false);
         let mut new_contents = &*contents.to_string();
 
-        let replacement_tokens = transpiler.tokenize(true);
+        let replacement_tokens = compiler.tokenize(true);
 
         let mut replacement_map: HashMap<String, String> = HashMap::new();
         let mut current_name = &String::new();
@@ -76,7 +76,7 @@ impl Transpiler<'_> {
         let mut index_offset: usize = 0;
         let mut looping = true;
         let mut new_contents = String::new();
-        let mut chars = Transpiler::get_chars();
+        let mut chars = Compiler::get_chars();
 
         for i in 0..tokens.len() {
             let token = tokens.get(i).unwrap();
@@ -103,12 +103,11 @@ impl Transpiler<'_> {
                     ),
                     Token::EndWhileLoop => {
                         new_contents.push_str(&format!(":call while_{}\n", chars)[..]);
-                        chars = Transpiler::get_chars();
+                        chars = Compiler::get_chars();
 
                         // Tokenize new contents
-                        let tks =
-                            Transpiler::new(new_contents.clone(), &Settings::default(), false)
-                                .tokenize(false);
+                        let tks = Compiler::new(new_contents.clone(), &Settings::default(), false)
+                            .tokenize(false);
 
                         // When gettings indexes in the new tokens vector,
                         // the length and position of elements will have changed

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -15,12 +15,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-use super::Transpiler;
+use super::Compiler;
 use crate::token::Token;
 
 const DIGITS: [char; 10] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
-impl Transpiler<'_> {
+impl Compiler<'_> {
     /// Convert the provided file contents into a list of tokens
     pub fn tokenize(&mut self, get_definitions: bool) -> Vec<Token> {
         let mut tokens: Vec<Token> = Vec::new();
@@ -56,7 +56,7 @@ impl Transpiler<'_> {
             }
 
             // When building a while loop, the contents are stored as a string for a token
-            // Later, in the transpile function, the while loop is converted to two databind
+            // Later, in the compile function, the while loop is converted to two databind
             // functions.
             if building_while {
                 if building_condition {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,7 +17,7 @@
  */
 use serde::{Deserialize, Serialize};
 
-/// Settings for the transpiler
+/// Settings for the compiler
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {


### PR DESCRIPTION
Closes #30 

Replaces "transpile" with "compile" throughout the project, including filenames, variable names, functions, structs, and documentation.
