### PR TITLE
Fix datapack subfolders

### DIFF
--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -49,8 +49,9 @@ impl Compiler<'_> {
         tokens: Vec<Token>,
         namespace: Option<&str>,
         existing_var_map: Option<&HashMap<String, String>>,
+        subfolder: &str,
     ) -> CompileReturn {
-        let tokens = self.while_convert(tokens);
+        let tokens = self.while_convert(tokens, subfolder);
 
         let mut var_map: HashMap<String, String>;
         let mut tag_map: HashMap<String, Vec<String>> = HashMap::new();

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -69,7 +69,10 @@ impl Compiler<'_> {
     /// # Arguments
     ///
     /// - `tokens` - A list of tokens that may include while loops
-    pub fn while_convert(&self, tokens: Vec<Token>) -> Vec<Token> {
+    /// - `subfolder` - If the while loop is in a subfolder, the prefix
+    ///   to put before the function name (eg. should be `Some("cmd/")` for
+    ///   a subfolder called `cmd`). Can be an empty string if there is no prefix
+    pub fn while_convert(&self, tokens: Vec<Token>, subfolder: &str) -> Vec<Token> {
         let mut new_tokens = tokens.clone();
 
         let mut while_index: usize = 0;
@@ -85,24 +88,26 @@ impl Compiler<'_> {
                     Token::WhileCondition(condition) => new_contents.push_str(
                         &format!(
                             ":func while_{chars}\n\
-                             execute if {condition} run :call condition_{chars}\n\
+                             execute if {condition} run :call {subfolder}condition_{chars}\n\
                              :endfunc\n",
                             chars = chars,
-                            condition = condition
+                            condition = condition,
+                            subfolder = subfolder
                         )[..],
                     ),
                     Token::WhileContents(contents) => new_contents.push_str(
                         &format!(
                             ":func condition_{chars}\n\
                              {contents}\n\
-                             :call while_{chars}\n\
+                             :call {subfolder}while_{chars}\n\
                              :endfunc\n",
                             chars = chars,
-                            contents = contents
+                            contents = contents,
+                            subfolder = subfolder
                         )[..],
                     ),
                     Token::EndWhileLoop => {
-                        new_contents.push_str(&format!(":call while_{}\n", chars)[..]);
+                        new_contents.push_str(&format!(":call {}while_{}\n", subfolder, chars)[..]);
                         chars = Compiler::get_chars();
 
                         // Tokenize new contents

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,6 @@ struct TagFile<'a> {
 }
 
 /// Get namespace (name of folder containing the main /functions)
-/// If there are multiple /functions folders, uses the one closest
-/// to the project root
 fn get_namespace<P: AsRef<Path>>(functions_path: &P) -> Result<&str, &str> {
     let namespace_folder = functions_path
         .as_ref()
@@ -47,14 +45,43 @@ fn get_namespace<P: AsRef<Path>>(functions_path: &P) -> Result<&str, &str> {
         .unwrap()
         .split("functions")
         .next()
-        .unwrap()
-        .strip_suffix(|x: char| ['\\', '/'].contains(&x))
         .unwrap();
+
+    let namespace_folder =
+        if let Some(new) = namespace_folder.strip_suffix(|x: char| ['\\', '/'].contains(&x)) {
+            new
+        } else {
+            namespace_folder
+        };
 
     let folders = namespace_folder.split(|x: char| ['\\', '/'].contains(&x));
     Ok(folders.last().unwrap())
 }
 
+/// Get the prefix of a subfolder before a function call (eg. `"cmd/"` for
+/// a subfolder called `cmd`)
+fn get_subfolder_prefix<P: AsRef<Path>>(functions_path: &P) -> String {
+    let mut after_functions = PathBuf::from(
+        functions_path
+            .as_ref()
+            .to_str()
+            .unwrap()
+            .split("functions")
+            .last()
+            .unwrap(),
+    );
+
+    after_functions.pop();
+
+    // Ensure no backslashes and remove leading slash, if present
+    let prefix = after_functions.to_str().unwrap().replace('\\', "/");
+
+    if let Some(new) = prefix.strip_prefix('/') {
+        format!("{}/", new)
+    } else {
+        format!("{}/", prefix)
+    }
+}
 /// Convert multiple globs into a `Vec<PathBuf>`
 fn merge_globs(globs: &[String], prefix: &str) -> Vec<PathBuf> {
     let mut merged_globs: Vec<PathBuf> = Vec::new();
@@ -251,6 +278,7 @@ fn main() -> std::io::Result<()> {
                         tokens,
                         Some(get_namespace(&entry.path()).unwrap()),
                         Some(&var_map),
+                        &get_subfolder_prefix(&entry.path()),
                     );
 
                     var_map = compiled.var_map;

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,8 +292,12 @@ fn main() -> std::io::Result<()> {
                         for (_, funcs) in compiled.tag_map.iter_mut() {
                             if funcs.contains(key) {
                                 let i = funcs.iter().position(|x| x == key).unwrap();
-                                funcs[i] =
-                                    format!("{}:{}", get_namespace(&entry.path()).unwrap(), key);
+                                funcs[i] = format!(
+                                    "{}:{}{}",
+                                    get_namespace(&entry.path()).unwrap(),
+                                    get_subfolder_prefix(&entry.path()),
+                                    key
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
Closes #29 

Fixes problems with tagging, calling, and while loops in subfolder functions.

- [x] Fix tagging functions in subfolders
- [x] Fix calling functions from a file in a subfolder
- [x] Fix while loop calls