### PR TITLE
Fix weird problems

### DIFF
--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -114,6 +114,8 @@ impl Compiler<'_> {
                         let tks = Compiler::new(new_contents.clone(), &Settings::default(), false)
                             .tokenize(false);
 
+                        new_contents = String::new();
+
                         // When gettings indexes in the new tokens vector,
                         // the length and position of elements will have changed
                         // due to new things being added

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -59,6 +59,16 @@ impl Compiler<'_> {
             // Later, in the compile function, the while loop is converted to two databind
             // functions.
             if building_while {
+                if current_keyword.trim() == ":endwhile" {
+                    building_while = false;
+                    building_keyword = false;
+                    current_keyword = String::new();
+                    tokens.push(Token::WhileContents(while_lines.join("\n")));
+                    while_line = String::new();
+                    while_lines = Vec::new();
+                    tokens.push(Token::EndWhileLoop);
+                }
+
                 if building_condition {
                     if self.current_char == '\n' {
                         tokens.push(Token::WhileCondition(current_keyword.trim().to_string()));
@@ -72,14 +82,6 @@ impl Compiler<'_> {
                         while_lines.push(while_line.trim().to_string());
                         while_line = String::new();
                     }
-                }
-
-                if current_keyword.trim() == ":endwhile" {
-                    building_while = false;
-                    tokens.push(Token::WhileContents(while_lines.join("\n")));
-                    while_line = String::new();
-                    while_lines = Vec::new();
-                    tokens.push(Token::EndWhileLoop);
                 }
             }
 
@@ -137,10 +139,6 @@ impl Compiler<'_> {
                         tokens.push(Token::WhileLoop);
                         building_while = true;
                         building_condition = true;
-                    }
-                    "endwhile" => {
-                        tokens.push(Token::EndWhileLoop);
-                        building_keyword = false;
                     }
                     _ => keyword_found = false,
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ fn main() -> std::io::Result<()> {
         if let Ok(config) = config_location {
             // Get base directory of project from config file location
             let base_dir = config.parent().unwrap();
-            args.push(format!("{}/src", base_dir.display()));
+            args.push(base_dir.to_str().unwrap().into());
             cli::get_app().get_matches_from(args)
         } else {
             // Run with no args to show help menu

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,9 @@ fn get_subfolder_prefix<P: AsRef<Path>>(functions_path: &P) -> String {
     // Ensure no backslashes and remove leading slash, if present
     let prefix = after_functions.to_str().unwrap().replace('\\', "/");
 
-    if let Some(new) = prefix.strip_prefix('/') {
+    if prefix == "/" {
+        String::new()
+    } else if let Some(new) = prefix.strip_prefix('/') {
         format!("{}/", new)
     } else {
         format!("{}/", prefix)


### PR DESCRIPTION
Fixes the following problems from #36:

- [x] Fix output folder
      When running `databind` with no arguments, the output folder is
      created relative to the directory the command was run is as opposed to
      the root of the project.
- [x] Fix problems with tagging
      Tags of folders that are *not* in subfolders have a preceding slash before
      the function name (eg. `namespace:/funcname` instead of `namespace:funcname`)
- [x] Fix while loops breaking
       `.databind` files seem to stop being transpiled after a while loop, and the while loop
       functions are not generated. I'm not sure what's causing this.