### PR TITLE
Fix comments breaking tags

### DIFF
--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -349,6 +349,7 @@ impl Compiler<'_> {
             } else if self.current_char == '#'
                 && tokens.last().ok_or(Token::None).is_ok()
                 && tokens.last().unwrap() == &Token::NewLine
+                && current_non_databind.is_empty()
             {
                 comment = true;
                 continue;


### PR DESCRIPTION
Closes #39 

Fixes comments breaking tags and adds a test to ensure that tags are included in output.