### PR TITLE
Rewrite tokenizer

### DIFF
--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -98,7 +98,7 @@ impl Compiler {
                 }
                 Token::TestVarName(var) | Token::OpVarName(var) => {
                     current_var = var.clone();
-                    let to_front = if active_token == Token::TestVar {
+                    let to_front = if let Token::TestVarName(_) = token {
                         "score "
                     } else {
                         ""

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -59,7 +59,7 @@ impl Compiler {
 
         // Remove :def lines
         let re = Regex::new(":def.*\n").unwrap();
-        re.replace(&new_contents[..], "").to_string()
+        re.replace(new_contents, "").to_string()
     }
 
     /// Replace while loops with databind function definitions and expand
@@ -125,7 +125,7 @@ impl Compiler {
                     }
                     Token::ScoreboardOperation => {
                         new_tokens[i + index_offset] =
-                            Token::NonDatabind("scoreboard players operation".into());
+                            Token::NonDatabind("scoreboard players operation ".into());
                     }
                     _ => {}
                 }

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -95,10 +95,7 @@ impl Compiler {
             () => {
                 if self.current_char.is_whitespace() {
                     let var_value: i32 = current_keyword.parse().unwrap();
-                    tokens.push(Token::Int(var_value));
-                    building_for = Token::None;
-                    building_first_token = true;
-                    current_keyword = String::new();
+                    add_token_and_reset!(Token::Int(var_value));
                 } else if DIGITS.contains(&self.current_char) {
                     current_keyword.push(self.current_char);
                 } else {

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -145,6 +145,13 @@ impl Compiler {
                 }
             }
 
+            if get_definitions && !tokens.is_empty() {
+                match tokens.last().unwrap() {
+                    Token::DefineReplace | Token::ReplaceName(_) | Token::ReplaceContents(_) => {}
+                    _ => break,
+                }
+            }
+
             if building_first_token {
                 if self.current_char.is_whitespace() {
                     if !current_token.is_empty() {

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -44,14 +44,14 @@ impl Compiler {
         }
 
         macro_rules! set_building {
-            ($token: expr, $params: expr) => {
+            ($token: expr, $params: expr) => {{
                 current_token = String::new();
                 tokens.push($token);
                 building_first_token = false;
                 building_for = $token;
                 params_left = $params;
                 next_char!();
-            };
+            }};
         }
 
         /// Add a token to the list
@@ -84,10 +84,10 @@ impl Compiler {
         }
 
         macro_rules! no_args_add {
-            ($token: expr) => {
+            ($token: expr) => {{
                 tokens.push($token);
                 current_token = String::new();
-            };
+            }};
         }
 
         /// Add an integer to the token list and reset variables
@@ -129,10 +129,8 @@ impl Compiler {
                     }
                     params_left -= 1;
                     current_token = String::new();
-                    true
                 } else {
                     current_token.push(self.current_char);
-                    false
                 }
             };
         }
@@ -156,50 +154,24 @@ impl Compiler {
                 if self.current_char.is_whitespace() {
                     if !current_token.is_empty() {
                         match &current_token[..] {
-                            ":func" => {
-                                set_building!(Token::DefineFunc, 1);
-                            }
-                            ":tag" => {
-                                set_building!(Token::Tag, 1);
-                            }
-                            ":endfunc" => {
-                                no_args_add!(Token::EndFunc);
-                            }
-                            ":var" => {
-                                set_building!(Token::Var, 3);
-                            }
-                            ":obj" => {
-                                set_building!(Token::Objective, 2);
-                            }
-                            ":sobj" => {
-                                set_building!(Token::SetObjective, 4);
-                            }
-                            ":call" => {
-                                set_building!(Token::CallFunc, 1);
-                            }
-                            ":tvar" => {
-                                set_building!(Token::TestVar, 1);
-                            }
-                            ":gvar" => {
-                                set_building!(Token::GetVar, 1);
-                            }
-                            ":def" => {
-                                set_building!(Token::DefineReplace, 2);
-                            }
+                            ":func" => set_building!(Token::DefineFunc, 1),
+                            ":tag" => set_building!(Token::Tag, 1),
+                            ":endfunc" => no_args_add!(Token::EndFunc),
+                            ":var" => set_building!(Token::Var, 3),
+                            ":obj" => set_building!(Token::Objective, 2),
+                            ":sobj" => set_building!(Token::SetObjective, 4),
+                            ":call" => set_building!(Token::CallFunc, 1),
+                            ":tvar" => set_building!(Token::TestVar, 1),
+                            ":gvar" => set_building!(Token::GetVar, 1),
+                            ":def" => set_building!(Token::DefineReplace, 2),
                             ":while" => {
                                 tokens.push(Token::WhileLoop);
                                 building_while = true;
                                 building_while_condition = true;
                             }
-                            ":sbop" => {
-                                no_args_add!(Token::ScoreboardOperation);
-                            }
-                            ":delvar" | ":delobj" => {
-                                set_building!(Token::DeleteVar, 1);
-                            }
-                            _ => {
-                                no_args_add!(Token::NonDatabind(format!("{} ", current_token)));
-                            }
+                            ":sbop" => no_args_add!(Token::ScoreboardOperation),
+                            ":delvar" | ":delobj" => set_building!(Token::DeleteVar, 1),
+                            _ => no_args_add!(Token::NonDatabind(format!("{} ", current_token))),
                         };
                         if self.current_char == '\n' {
                             tokens.push(Token::NewLine);
@@ -224,9 +196,7 @@ impl Compiler {
                                 add_token!(Token::ModVarName(current_token));
                             }
                             // Assignment operator
-                            2 => {
-                                assignment_operator!();
-                            }
+                            2 => assignment_operator!(),
                             // Value
                             _ => add_int_and_reset!(),
                         }
@@ -250,9 +220,7 @@ impl Compiler {
                         3 => {
                             add_token!(Token::ObjectiveName(current_token));
                         }
-                        2 => {
-                            assignment_operator!();
-                        }
+                        2 => assignment_operator!(),
                         _ => add_int_and_reset!(),
                     },
                     Token::Tag => add_token_and_reset!(Token::TagName(current_token)),
@@ -264,6 +232,7 @@ impl Compiler {
                             if ['\r', '\n'].contains(&self.current_char) {
                                 tokens.push(Token::ReplaceContents(current_token));
                                 building_for = Token::None;
+                                building_first_token = true;
                                 current_token = String::new();
                             } else {
                                 current_token.push(self.current_char);

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -28,12 +28,20 @@ impl Compiler {
         let mut comment = false;
         let mut building_first_token = true;
         let mut current_keyword = String::new();
+        let mut last_char = '\n';
 
         let mut building_while = false;
         let mut building_while_condition = false;
 
         let mut building_for = Token::None;
         let mut params_left = 0;
+
+        macro_rules! next_char {
+            () => {
+                last_char = self.current_char;
+                self.next_char();
+            };
+        }
 
         macro_rules! set_building {
             ($token: expr, $params: expr) => {
@@ -42,7 +50,7 @@ impl Compiler {
                 building_first_token = false;
                 building_for = $token;
                 params_left = $params;
-                self.next_char();
+                next_char!();
             };
         }
 
@@ -134,7 +142,7 @@ impl Compiler {
 
         while self.current_char != '\u{0}' {
             while comment {
-                self.next_char();
+                next_char!();
                 if self.current_char == '\n' {
                     comment = false;
                 }
@@ -193,11 +201,15 @@ impl Compiler {
                             tokens.push(Token::NewLine);
                         }
                     } else {
-                        self.next_char();
+                        next_char!();
                     }
                 } else {
+                    if last_char == '\n' && self.current_char == '#' {
+                        comment = true;
+                        continue;
+                    }
                     current_keyword.push(self.current_char);
-                    self.next_char();
+                    next_char!();
                 }
             } else {
                 match building_for {
@@ -261,7 +273,7 @@ impl Compiler {
                 if self.current_char == '\n' {
                     tokens.push(Token::NewLine);
                 }
-                self.next_char();
+                next_char!();
             }
         }
 

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -19,26 +19,32 @@ use super::Compiler;
 use crate::token::Token;
 
 const DIGITS: [char; 11] = ['-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+const ASSIGNMENT_OPERATORS: [&str; 4] = [".=", "=", "+=", "-="];
 
 impl Compiler {
     /// Convert the provided file contents into a list of tokens
     pub fn tokenize(&mut self, get_definitions: bool) -> Vec<Token> {
         let mut tokens: Vec<Token> = Vec::new();
-
-        let assignment_operators = [".=", "=", "+=", "-="];
-
-        let mut last_char = ' ';
-        let mut current_keyword = String::new();
-        let mut building_keyword = false;
-        let mut building_token = Token::None;
-        let mut building_while = false;
-        let mut while_line = String::new();
-        let mut while_lines: Vec<String> = Vec::new();
-        let mut building_condition = false;
-        let mut remaining_params = 0;
-        let mut first_whitespace = false;
-        let mut current_non_databind = String::new();
         let mut comment = false;
+        let mut building_first_token = true;
+        let mut current_keyword = String::new();
+
+        let mut building_while = false;
+        let mut building_while_condition = false;
+
+        let mut building_for = Token::None;
+        let mut params_left = 0;
+
+        macro_rules! set_building {
+            ($token: expr, $params: expr) => {
+                current_keyword = String::new();
+                tokens.push($token);
+                building_first_token = false;
+                building_for = $token;
+                params_left = $params;
+                self.next_char();
+            };
+        }
 
         /// Add a token to the list
         ///
@@ -50,6 +56,7 @@ impl Compiler {
                 if self.current_char.is_whitespace() {
                     tokens.push($token);
                     current_keyword = String::new();
+                    params_left -= 1;
                     true
                 } else {
                     current_keyword.push(self.current_char);
@@ -62,10 +69,16 @@ impl Compiler {
         macro_rules! add_token_and_reset {
             ($token: expr) => {
                 if add_token!($token) {
-                    building_keyword = false;
-                    building_token = Token::None;
-                    first_whitespace = false;
+                    building_for = Token::None;
+                    building_first_token = true;
                 }
+            };
+        }
+
+        macro_rules! no_args_add {
+            ($token: expr) => {
+                tokens.push($token);
+                current_keyword = String::new();
             };
         }
 
@@ -75,24 +88,15 @@ impl Compiler {
                 if self.current_char.is_whitespace() {
                     let var_value: i32 = current_keyword.parse().unwrap();
                     tokens.push(Token::Int(var_value));
-                    building_keyword = false;
-                    building_token = Token::None;
+                    building_for = Token::None;
+                    building_first_token = true;
                     current_keyword = String::new();
-                    first_whitespace = false;
                 } else if DIGITS.contains(&self.current_char) {
                     current_keyword.push(self.current_char);
                 } else {
                     println!("[ERROR] Variables can only store integers.");
                     std::process::exit(1);
                 }
-            };
-        }
-
-        /// Add a token to the tokens list and set the token being built
-        macro_rules! set_building {
-            ($token: expr) => {
-                tokens.push($token);
-                building_token = $token;
             };
         }
 
@@ -104,7 +108,7 @@ impl Compiler {
         macro_rules! assignment_operator {
             () => {
                 if self.current_char.is_whitespace() {
-                    if assignment_operators.contains(&&current_keyword[..]) {
+                    if ASSIGNMENT_OPERATORS.contains(&&current_keyword[..]) {
                         match &current_keyword[..] {
                             ".=" => tokens.push(Token::InitialSet),
                             "=" => tokens.push(Token::VarSet),
@@ -118,6 +122,7 @@ impl Compiler {
                         println!("Invalid assignment operator provided");
                         std::process::exit(1);
                     }
+                    params_left -= 1;
                     current_keyword = String::new();
                     true
                 } else {
@@ -135,128 +140,76 @@ impl Compiler {
                 }
             }
 
-            if get_definitions && !tokens.is_empty() {
-                match tokens.last().unwrap() {
-                    Token::DefineReplace | Token::ReplaceName(_) | Token::ReplaceContents(_) => {}
-                    _ => break,
-                }
-            }
-
-            // When building a while loop, the contents are stored as a string for a token
-            // Later, in the compile function, the while loop is converted to two databind
-            // functions.
-            if building_while {
-                if current_keyword.trim() == ":endwhile" {
-                    building_while = false;
-                    building_keyword = false;
-                    current_keyword = String::new();
-                    tokens.push(Token::WhileContents(while_lines.join("\n")));
-                    while_line = String::new();
-                    while_lines = Vec::new();
-                    tokens.push(Token::EndWhileLoop);
-                }
-
-                if building_condition {
-                    if self.current_char == '\n' {
-                        tokens.push(Token::WhileCondition(current_keyword.trim().to_string()));
-                        current_keyword = String::new();
-                        building_condition = false;
+            if building_first_token {
+                if self.current_char.is_whitespace() {
+                    if !current_keyword.is_empty() {
+                        match &current_keyword[..] {
+                            ":func" => {
+                                set_building!(Token::DefineFunc, 1);
+                            }
+                            ":tag" => {
+                                set_building!(Token::Tag, 1);
+                            }
+                            ":endfunc" => {
+                                no_args_add!(Token::EndFunc);
+                            }
+                            ":var" => {
+                                set_building!(Token::Var, 3);
+                            }
+                            ":obj" => {
+                                set_building!(Token::Objective, 2);
+                            }
+                            ":sobj" => {
+                                set_building!(Token::SetObjective, 4);
+                            }
+                            ":call" => {
+                                set_building!(Token::CallFunc, 1);
+                            }
+                            ":tvar" => {
+                                set_building!(Token::TestVar, 1);
+                            }
+                            ":gvar" => {
+                                set_building!(Token::GetVar, 1);
+                            }
+                            ":def" => {
+                                set_building!(Token::DefineReplace, 2);
+                            }
+                            ":while" => {
+                                tokens.push(Token::WhileLoop);
+                                building_while = true;
+                                building_while_condition = true;
+                            }
+                            ":sbop" => {
+                                no_args_add!(Token::ScoreboardOperation);
+                            }
+                            ":delvar" | ":delobj" => {
+                                set_building!(Token::DeleteVar, 1);
+                            }
+                            _ => {
+                                no_args_add!(Token::NonDatabind(format!("{} ", current_keyword)));
+                            }
+                        };
+                        if self.current_char == '\n' {
+                            tokens.push(Token::NewLine);
+                        }
+                    } else {
+                        self.next_char();
                     }
                 } else {
-                    while_line.push(self.current_char);
-                    if self.current_char == '\n' {
-                        current_keyword = String::new();
-                        while_lines.push(while_line.trim().to_string());
-                        while_line = String::new();
-                    }
-                }
-            }
-
-            if !building_keyword && last_char.is_whitespace() && self.current_char == ':' {
-                building_keyword = true;
-                if !current_non_databind.is_empty() {
-                    tokens.push(Token::NonDatabind(current_non_databind));
-                    current_non_databind = String::new();
-                }
-            } else if building_keyword && building_token == Token::None {
-                current_keyword.push(self.current_char);
-                let mut keyword_found = true;
-                match &current_keyword[..] {
-                    "var" => {
-                        set_building!(Token::Var);
-                        remaining_params = 3;
-                    }
-                    "obj" => {
-                        set_building!(Token::Objective);
-                        remaining_params = 2;
-                    }
-                    "sobj" => {
-                        set_building!(Token::SetObjective);
-                        remaining_params = 4;
-                    }
-                    "tvar" => {
-                        set_building!(Token::TestVar);
-                    }
-                    "func" => {
-                        set_building!(Token::DefineFunc);
-                    }
-                    "endfunc" => {
-                        tokens.push(Token::EndFunc);
-                        building_keyword = false;
-                    }
-                    "def" => {
-                        set_building!(Token::DefineReplace);
-                        remaining_params = 2;
-                    }
-                    "tag" => {
-                        set_building!(Token::Tag);
-                    }
-                    "call" => {
-                        set_building!(Token::CallFunc);
-                    }
-                    "while" => {
-                        tokens.push(Token::WhileLoop);
-                        building_while = true;
-                        building_condition = true;
-                    }
-                    "gvar" => {
-                        set_building!(Token::GetVar);
-                    }
-                    "sbop" => {
-                        tokens.push(Token::ScoreboardOperation);
-                        building_keyword = false;
-                    }
-                    "delvar" | "delobj" => {
-                        set_building!(Token::DeleteVar);
-                    }
-                    _ => keyword_found = false,
-                }
-
-                if keyword_found {
-                    current_keyword = String::new();
-                }
-            } else if building_keyword {
-                if self.current_char.is_whitespace() && !first_whitespace {
-                    first_whitespace = true;
-                    last_char = self.current_char;
+                    current_keyword.push(self.current_char);
                     self.next_char();
-                    continue;
                 }
-
-                match building_token {
+            } else {
+                match building_for {
                     Token::Var => {
-                        match remaining_params {
+                        match params_left {
                             // Variable name
                             3 => {
-                                if add_token!(Token::ModVarName(current_keyword)) {
-                                    remaining_params -= 1;
-                                }
+                                add_token!(Token::ModVarName(current_keyword));
                             }
                             // Assignment operator
                             2 => {
-                                if assignment_operator!() {
-                                    remaining_params -= 1;
-                                }
+                                assignment_operator!();
                             }
                             // Value
                             _ => add_int_and_reset!(),
@@ -268,46 +221,34 @@ impl Compiler {
                     Token::DefineFunc | Token::CallFunc => {
                         add_token_and_reset!(Token::FuncName(current_keyword));
                     }
-                    Token::Objective => match remaining_params {
+                    Token::Objective => match params_left {
                         2 => {
-                            if add_token!(Token::ObjectiveName(current_keyword)) {
-                                remaining_params -= 1;
-                            }
+                            add_token!(Token::ObjectiveName(current_keyword));
                         }
                         _ => add_token_and_reset!(Token::ObjectiveType(current_keyword)),
                     },
-                    Token::SetObjective => match remaining_params {
+                    Token::SetObjective => match params_left {
                         4 => {
-                            if add_token!(Token::Target(current_keyword)) {
-                                remaining_params -= 1;
-                            }
+                            add_token!(Token::Target(current_keyword));
                         }
                         3 => {
-                            if add_token!(Token::ObjectiveName(current_keyword)) {
-                                remaining_params -= 1;
-                            }
+                            add_token!(Token::ObjectiveName(current_keyword));
                         }
                         2 => {
-                            if assignment_operator!() {
-                                remaining_params -= 1;
-                            }
+                            assignment_operator!();
                         }
                         _ => add_int_and_reset!(),
                     },
                     Token::Tag => add_token_and_reset!(Token::TagName(current_keyword)),
-                    Token::DefineReplace => match remaining_params {
+                    Token::DefineReplace => match params_left {
                         2 => {
-                            if add_token!(Token::ReplaceName(current_keyword)) {
-                                remaining_params -= 1;
-                            }
+                            add_token!(Token::ReplaceName(current_keyword));
                         }
                         _ => {
                             if ['\r', '\n'].contains(&self.current_char) {
                                 tokens.push(Token::ReplaceContents(current_keyword));
-                                building_keyword = false;
-                                building_token = Token::None;
+                                building_for = Token::None;
                                 current_keyword = String::new();
-                                first_whitespace = false;
                             } else {
                                 current_keyword.push(self.current_char);
                             }
@@ -317,30 +258,11 @@ impl Compiler {
                     Token::DeleteVar => add_token_and_reset!(Token::DelVarName(current_keyword)),
                     _ => {}
                 };
-            } else if self.current_char == '#'
-                && tokens.last().ok_or(Token::None).is_ok()
-                && tokens.last().unwrap() == &Token::NewLine
-                && current_non_databind.is_empty()
-            {
-                comment = true;
-                continue;
-            } else if !['\r', '\n'].contains(&self.current_char) {
-                current_non_databind.push(self.current_char);
-            } else if !current_non_databind.is_empty() {
-                tokens.push(Token::NonDatabind(current_non_databind));
-                current_non_databind = String::new();
+                if self.current_char == '\n' {
+                    tokens.push(Token::NewLine);
+                }
+                self.next_char();
             }
-
-            if self.current_char == '\n' && !building_while {
-                tokens.push(Token::NewLine);
-            }
-
-            last_char = self.current_char;
-            self.next_char();
-        }
-
-        if !current_non_databind.is_empty() {
-            tokens.push(Token::NonDatabind(current_non_databind));
         }
 
         tokens


### PR DESCRIPTION
Closes #54 

Rewrites the `tokenize()` function as described in the issue.

To do:

- [x] Add back while loop support
- [x] Stop `replace_definitions()` tokenizing the entire file
- [x] Add back comment support