### PR TITLE
 Fix duplicate labels in docs

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,7 +4,7 @@ Databind CLI
 What Can Be Compiled
 ----------------------
 
-Databind compiles Databind projects (see :ref:`Creating a Project`).
+Databind compiles Databind projects (see :ref:`getting_started:Creating a Project`).
 Databind will look for included files (``**/*.databind`` by default) and
 leave other files alone.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ release = '0.4.0'
 # ones.
 extensions = ['sphinx_rtd_theme', 'sphinx.ext.autosectionlabel']
 
+autosectionlabel_prefix_document = True
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -98,5 +98,5 @@ Would not generate any output.
 See Examples
 ------------
 
-If you want to see some examples of language features, go to the :ref:`Examples`.
+If you want to see some examples of language features, go to the :ref:`examples:Examples`.
 Otherwise, you may continue to the next page.


### PR DESCRIPTION
Closes #70 

Sets `autosectionlabel_prefix_doucment` to `True` to fix multiple labels with the same name.