### PR TITLE
Add Folder Structure to docs

### DIFF
--- a/docs/folder_structure.rst
+++ b/docs/folder_structure.rst
@@ -1,0 +1,30 @@
+Folder Structure
+================
+
+How the folder structure of Databind works.
+
+In a project started with ``databind create``, the file structure
+might look something like this:
+
+.. code-block:: text
+
+   project_root
+   │  databind.toml
+   │  LICENSE
+   │  README.md
+   └──src
+      │   pack.mcmeta
+      │   pack.png
+      └───data
+          └───namespace
+              └───functions
+                      main.databind
+
+All of the Databind-related files (other than the configuration file)
+are contained in the `src/` directory. Other files such as the project's
+license and the README are just in the root. These files are not generated
+by default, but they've been added in the example to show where they might
+be placed.
+
+It's possible to create a project without using ``databind create``, but it's
+not ideal and bugs caused by it generally won't be fixed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,4 +10,5 @@ Contents:
    syntax.rst
    cli.rst
    config.rst
+   folder_structure.rst
    examples.rst


### PR DESCRIPTION
Adds a documentation page with the folder structure of a Databind project.
