### PR TITLE
Update workflows

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -2,4 +2,6 @@ source: src/**
 databind create: src/create_project.rs
 documentation: docs/**
 tests: tests/**
-workflows: .github/workflows/**
+workflows:
+  - .github/workflows/**
+  - .github/labeler.yaml

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -27,7 +27,7 @@ jobs:
           toolchain: stable
 
       - name: Build
-        run: cargo build --release --all-features
+        run: cargo build --all-features
 
       - name: Test
         run: cargo test --all-features
@@ -45,7 +45,7 @@ jobs:
           toolchain: stable
 
       - name: Build
-        run: cargo build --release --all-features
+        run: cargo build --all-features
 
       - name: Test
         run: cargo test --all-features
@@ -63,7 +63,7 @@ jobs:
           toolchain: stable
 
       - name: Build
-        run: cargo build --release --all-features
+        run: cargo build --all-features
 
       - name: Test
         run: cargo test --all-features

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -8,6 +8,7 @@ on:
       - docs/**
       - tests/**
       - .github/workflows/**
+      - .github/labeler.yaml
 
 jobs:
   label:

--- a/.github/workflows/pr_license_check.yaml
+++ b/.github/workflows/pr_license_check.yaml
@@ -4,8 +4,7 @@ on:
     branches:
       - master
     paths:
-      - src/**
-      - tests/**
+      - '**/*.rs'
       - README.md
       - docs/conf.py
 


### PR DESCRIPTION
Makes both `cargo build` and `cargo test` in workflows use the debug build. Currently, `cargo build` has the `--release` flag but `cargo test` does not.
Also updates a match for the PR Labeler workflow and some workflow paths.
