### PR TITLE
Add CLI argument to set `pack_format`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,14 @@ pub fn get_app<'a, 'b>() -> App<'a, 'b> {
                         .long("path")
                         .takes_value(true)
                         .value_name("PATH"),
+                )
+                .arg(
+                    Arg::with_name("version")
+                        .help("The pack_format for the pack.mcmeta file")
+                        .long("version")
+                        .takes_value(true)
+                        .default_value("7")
+                        .value_name("VERSION"),
                 ),
         )
 }

--- a/src/create_project.rs
+++ b/src/create_project.rs
@@ -20,7 +20,7 @@ use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-fn make_pack_mcmeta(description: String) -> Result<String, serde_json::Error> {
+fn make_pack_mcmeta(description: String, version: u8) -> Result<String, serde_json::Error> {
     #[derive(Serialize)]
     struct Pack {
         pack_format: u8,
@@ -34,7 +34,7 @@ fn make_pack_mcmeta(description: String) -> Result<String, serde_json::Error> {
 
     let pack = PackMcMeta {
         pack: Pack {
-            pack_format: 6,
+            pack_format: version,
             description,
         },
     };
@@ -67,6 +67,7 @@ pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
     } else {
         name
     };
+    let version: u8 = args.value_of("version").unwrap().parse().unwrap();
 
     let mut path = PathBuf::from(base_path);
 
@@ -102,7 +103,7 @@ pub fn create_project(args: clap::ArgMatches) -> std::io::Result<()> {
     path.pop();
 
     // Create pack.mcmeta
-    let pack_mcmeta = make_pack_mcmeta(description)?;
+    let pack_mcmeta = make_pack_mcmeta(description, version)?;
     path.push("pack.mcmeta");
     fs::write(&path, pack_mcmeta)?;
 

--- a/tests/other_tests.rs
+++ b/tests/other_tests.rs
@@ -98,7 +98,7 @@ fn test_create_structure() {
         let contents_pack: PackMcMeta = serde_json::from_str(&contents).unwrap();
         let expected_pack = PackMcMeta {
             pack: Pack {
-                pack_format: 6,
+                pack_format: 7,
                 description: "test_create_structure description".into(),
             },
         };


### PR DESCRIPTION
Adds an argument for `databind create` to set the `pack_format` of the `pack.mcmeta` file.