### PR TITLE
Change global macro symbol from `@` to `!`

### DIFF
--- a/docs/macros.rst
+++ b/docs/macros.rst
@@ -181,17 +181,17 @@ in-game, we could run the following:
 Files for macros
 ----------------
 
-Any file whose name starts with an ``@`` symbol is able to define macros
+Any file whose name starts with an ``!`` symbol is able to define macros
 that work anywhere in the project. These files, if they only contain macros,
 should generally be placed right in the ``src/`` directory as opposed to
 in a namespace's ``functions/`` directory, however you can place them wherever
 you'd like.
 
-It's important to note that the reason the ``@`` was chosen is that the compiler
+It's important to note that the reason the ``!`` was chosen is that the compiler
 goes through the ``src/`` directory in alphabetical order. This means that if you,
 for example, have two namespaces, ``abc`` and ``xyz``, macros defined in ``xyz``
 will not be available in ``abc``. A good idea is to begin the names of any folders
-containing macro definitions with an ``@``, similar to the files. That way, they are
+containing macro definitions with an ``!``, similar to the files. That way, they are
 always compiled first.
 
 Macros that contain calls to other macros can be defined in any order. If you have

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -36,7 +36,7 @@ impl Compiler {
     ///
     /// - `tokens` - A list of tokens to look for macro calls in
     /// - `return_macros` - Whether to return the HashMap of macros.
-    ///   Used for global macros (files beginning with `@`)
+    ///   Used for global macros (files beginning with `!`)
     /// - `existing_macros` - Global macros to use
     pub fn parse_macros(
         &self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ fn main() -> std::io::Result<()> {
                         .unwrap()
                         .to_str()
                         .unwrap()
-                        .starts_with('@')
+                        .starts_with('!')
                     {
                         let ret = compile.compile(
                             tokens,


### PR DESCRIPTION
The way to define global macros in a project is currently to precede the filename with the `@` character (eg. `@macros.databind`). This character was arbitrarily chosen. The `!` character is used in macro definitions, so it would make more sense to start filenames with that instead.