### PR TITLE
Add functions to help integration tests

### DIFF
--- a/tests/file_contents_tests.rs
+++ b/tests/file_contents_tests.rs
@@ -20,7 +20,6 @@ use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str;
-use tempdir::TempDir;
 
 mod tests;
 
@@ -32,23 +31,7 @@ fn test_tag_syntax() {
         pub values: Vec<String>,
     }
 
-    let mut path = tests::resources();
-    path.push("test_tag_syntax");
-
-    let out = TempDir::new("test_tag_syntax").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let (out, mut path) = tests::run_in_tempdir("test_tag_syntax");
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
     let expected_tags = [
@@ -98,23 +81,7 @@ fn test_tag_syntax() {
 /// is not removed by comments
 #[test]
 fn test_tags_and_comments() {
-    let mut path = tests::resources();
-    path.push("test_tags_and_comments");
-
-    let out = TempDir::new("test_tags_and_comments").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let (out, mut path) = tests::run_in_tempdir("test_tags_and_comments");
 
     let expected_funcs = ["func1.mcfunction"];
     let expected_include = "kill @e[type=#test:tag_should_be_included]";
@@ -133,30 +100,7 @@ fn test_tags_and_comments() {
 /// Test that escaped keywords are properly escaped
 #[test]
 fn test_escape() {
-    let mut path = tests::resources();
-    path.push("test_escape");
-
-    let out = TempDir::new("test_escape").expect("Could not create tempdir for test");
-
-    println!(
-        "{}",
-        str::from_utf8(
-            &tests::run_with_args(
-                "cargo",
-                &[
-                    "run",
-                    "--",
-                    path.to_str().unwrap(),
-                    "--ignore-config",
-                    "--out",
-                    out.path().to_str().unwrap(),
-                ],
-                None,
-            )
-            .stdout
-        )
-        .unwrap()
-    );
+    let (out, mut path) = tests::run_in_tempdir("test_escape");
 
     let expected_funcs = [
         "main.mcfunction",
@@ -203,23 +147,7 @@ fn get_while_files<P: AsRef<Path>>(functions_path: P) -> WhileFiles {
 /// Test that the contents of generated while loop functions are correct
 #[test]
 fn test_while_creation() {
-    let mut path = tests::resources();
-    path.push("test_while_creation");
-
-    let out = TempDir::new("test_while_creation").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let out = tests::run_in_tempdir("test_while_creation").0;
 
     // Get the randomly-named while loop files
     let files = get_while_files(format!("{}/data/test/functions", out.path().display()));
@@ -250,10 +178,7 @@ fn test_while_creation() {
 /// formatting
 #[test]
 fn test_macro_replacement() {
-    let mut path = tests::resources();
-    path.push("test_macro_replacement");
-
-    let out = TempDir::new("test_macro_replacement").expect("Could not create tempdir for test");
+    let out = tests::run_in_tempdir("test_macro_replacement").0;
 
     let expected_lines = [
         "say Call Test 1",
@@ -272,19 +197,6 @@ fn test_macro_replacement() {
         "say Def Test 5",
     ];
 
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
-
     let out_path = format!(
         "{}/data/test/functions/main.mcfunction",
         out.path().display()
@@ -300,23 +212,7 @@ fn test_macro_replacement() {
 /// Test that macros calling other macros work properly
 #[test]
 fn test_macro_recursion() {
-    let mut path = tests::resources();
-    path.push("test_macro_recursion");
-
-    let out = TempDir::new("test_macro_recursion").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let out = tests::run_in_tempdir("test_macro_recursion").0;
 
     let out_path = format!(
         "{}/data/test/functions/main.mcfunction",
@@ -329,23 +225,7 @@ fn test_macro_recursion() {
 /// Test that global variables are properly read and replaced
 #[test]
 fn test_global_vars() {
-    let mut path = tests::resources();
-    path.push("test_global_vars");
-
-    let out = TempDir::new("test_global_vars").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let out = tests::run_in_tempdir("test_global_vars").0;
 
     let out_path = format!(
         "{}/data/test/functions/main.mcfunction",
@@ -360,23 +240,7 @@ fn test_global_vars() {
 /// Test that global macros are properly dealt with
 #[test]
 fn test_global_macros() {
-    let mut path = tests::resources();
-    path.push("test_global_macros");
-
-    let out = TempDir::new("test_global_macros").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let out = tests::run_in_tempdir("test_global_macros").0;
 
     let out_path = format!(
         "{}/data/test/functions/main.mcfunction",

--- a/tests/file_structure_tests.rs
+++ b/tests/file_structure_tests.rs
@@ -29,23 +29,7 @@ mod tests;
 /// Uses `tests/resources/test_file_structure`
 #[test]
 fn test_file_structure() {
-    let mut path = tests::resources();
-    path.push("test_file_structure");
-
-    let out = TempDir::new("test_file_structure").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let (out, mut path) = tests::run_in_tempdir("test_file_structure");
 
     let expected_funcs = [
         "load.mcfunction",
@@ -73,23 +57,7 @@ fn test_file_structure() {
 /// Test that nested functions are properly generated
 #[test]
 fn test_nested_funcs() {
-    let mut path = tests::resources();
-    path.push("test_nested_funcs");
-
-    let out = TempDir::new("test_nested_funcs").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let (out, mut path) = tests::run_in_tempdir("test_nested_funcs");
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
 
@@ -133,25 +101,7 @@ fn test_config() {
 
 #[test]
 fn test_no_config_out() {
-    let mut path = tests::resources();
-    path.push("test_no_config_out");
-    let path_str = path.to_str().unwrap();
-
-    let out = TempDir::new("test_no_config_out").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path_str,
-            "--config",
-            &format!("{}/should_not_be_made.toml", path_str)[..],
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let (out, mut path) = tests::run_in_tempdir("test_no_config_out");
 
     let expected_funcs = ["tick.mcfunction"];
     let expected_toml = ["should_be_made.toml"];
@@ -178,23 +128,7 @@ fn test_tag_generation() {
         pub values: Vec<String>,
     }
 
-    let mut path = tests::resources();
-    path.push("test_tag_generation");
-
-    let out = TempDir::new("test_tag_generation").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    let (out, mut path) = tests::run_in_tempdir("test_tag_generation");
 
     let expected_funcs = ["load.mcfunction", "tick.mcfunction", "func3.mcfunction"];
     let expected_tags = ["load.json", "tick.json", "second_tag.json", "func3.json"];
@@ -284,19 +218,7 @@ fn test_while_structure() {
     path.push("test_while_creation");
 
     let out = TempDir::new("test_while_structure").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    tests::run(out.path(), &path);
 
     let files: Vec<PathBuf> = glob(&format!(
         "{}/data/test/functions/*.mcfunction",
@@ -333,19 +255,7 @@ fn test_if_structure() {
     path.push("test_if_creation");
 
     let out = TempDir::new("test_if_structure").expect("Could not create tempdir for test");
-
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--",
-            path.to_str().unwrap(),
-            "--ignore-config",
-            "--out",
-            out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+    tests::run(out.path(), &path);
 
     let files: Vec<PathBuf> = glob(&format!(
         "{}/data/test/functions/*.mcfunction",

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use tempdir::TempDir;
 
 pub fn run_with_args(cmd: &str, args: &[&str], path: Option<&dyn AsRef<Path>>) -> Output {
     if let Some(p) = path {
@@ -86,4 +87,31 @@ pub fn check_files_dont_exist<P: AsRef<Path>>(
         );
         base.pop();
     }
+}
+
+/// Run Databind on a path and send output to a path
+pub fn run<P: AsRef<Path>>(out: P, path: P) {
+    run_with_args(
+        "cargo",
+        &[
+            "run",
+            "--",
+            path.as_ref().to_str().unwrap(),
+            "--ignore-config",
+            "--out",
+            out.as_ref().to_str().unwrap(),
+        ],
+        None,
+    );
+}
+
+/// Create a temporary output directory for a test and run
+/// Databind there
+pub fn run_in_tempdir(directory: &str) -> (TempDir, PathBuf) {
+    let mut path = resources();
+    path.push(directory);
+
+    let out = TempDir::new(directory).expect("Could not create tempdir for test");
+    run(out.path(), &path);
+    (out, path)
 }


### PR DESCRIPTION
Closes #98

Adds `run()` and `run_in_tempdir()` functions for integration tests to avoid a bunch of copy + pasted code.