### PR TITLE
Make Databind tags merge with normal tags if found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -378,24 +378,33 @@ fn main() -> std::io::Result<()> {
                 values: funcs.clone(),
             };
 
-            // Path to generated JSON file
-            let path_string = format!(
-                "{}/data/minecraft/tags/functions/{}.json",
-                target_folder, tag
-            );
-            let path = Path::new(&path_string);
+            {
+                // Path to potential source JSON file
+                let path_str = format!(
+                    "{}/data/minecraft/tags/functions/{}.json",
+                    src_dir.display(),
+                    tag
+                );
+                let path = Path::new(&path_str);
 
-            // Read existing tags if present
-            if path.exists() && path.is_file() {
-                let contents = fs::read_to_string(&path)?;
-                let mut existing_tags: TagFile = serde_json::from_str(&contents)?;
-                tag_file.values.append(&mut existing_tags.values);
+                // Read existing tags if present
+                if path.exists() && path.is_file() {
+                    let contents = fs::read_to_string(&path)?;
+                    let mut existing_tags: TagFile = serde_json::from_str(&contents)?;
+                    tag_file.values.append(&mut existing_tags.values);
+                }
             }
 
             let json = serde_json::to_string(&tag_file)?;
 
             // Write tag file
-            fs::write(path, json)?;
+            fs::write(
+                &format!(
+                    "{}/data/minecraft/tags/functions/{}.json",
+                    target_folder, tag
+                ),
+                json,
+            )?;
         }
     } else {
         println!("Databind does not support single-file compilation.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,11 @@ fn main() -> std::io::Result<()> {
             } else {
                 let filename = relative_path.file_name().unwrap().to_str().unwrap();
                 let full_path = format!("{}/{}", target_path, filename);
-                fs::copy(path, full_path)?;
+                // Only copy if the file doesn't exist yet
+                // Intended to stop overwriting of Databind tags
+                if fs::metadata(&full_path).is_err() {
+                    fs::copy(&path, &full_path)?;
+                }
             }
         }
 

--- a/tests/resources/test_existing_tags/data/minecraft/tags/functions/test.json
+++ b/tests/resources/test_existing_tags/data/minecraft/tags/functions/test.json
@@ -1,0 +1,3 @@
+{
+  "values": ["test:mcfunction_tagged"]
+}

--- a/tests/resources/test_existing_tags/data/test/functions/main.databind
+++ b/tests/resources/test_existing_tags/data/test/functions/main.databind
@@ -1,0 +1,2 @@
+func databind_tagged tag test end
+func mcfunction_tagged end


### PR DESCRIPTION
Closes #102

Previously, Databind would overwrite any function tags defined the normal mcfunction way (by creating a JSON file in data/minecraft/tags/functions). This changes that functionality to instead check if a file defined that way exists and, if it does, combine it with functions tagged the Databind way.

- [x] Implement #102 
- [x] Add tests