### PR TITLE
Fix NewLine token not being added with CRLF

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -36,7 +36,7 @@ impl Compiler {
         };
 
         Compiler {
-            chars: text.chars().collect(),
+            chars: text.chars().filter(|x| *x != '\r').collect(),
             position: 0,
             current_char: first_char,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+// Test
 #![warn(clippy::all)]
 
 use glob::glob;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// Test
 #![warn(clippy::all)]
 
 use glob::glob;


### PR DESCRIPTION
Closes #109

Fix the NewLine token not being added on newlines by filtering out all
carriage returns in the Compiler::new() function.