### PR TITLE
Fix globs in workflows

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,7 +1,7 @@
-source: src/**
+source: src/**/*
 databind create: src/create_project.rs
-documentation: docs/**
-tests: tests/**
+documentation: docs/**/*
+tests: tests/**/*
 workflows:
-  - .github/workflows/**
+  - .github/workflows/**/*
   - .github/labeler.yaml

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -4,14 +4,14 @@ on:
     branches:
       - master
     paths:
-      - src/**
-      - tests/**
+      - src/**/*
+      - tests/**/*
   push:
     branches:
       - master
     paths:
-      - src/**
-      - tests/**
+      - src/**/*
+      - tests/**/*
 
 jobs:
   windows_build:

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -4,12 +4,12 @@ on:
     branches:
       - master
     paths:
-      - docs/**
+      - docs/**/*
   push:
     branches:
       - master
     paths:
-      - docs/**
+      - docs/**/*
 
 jobs:
   build_docs:

--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -4,10 +4,10 @@ on:
     branches:
       - master
     paths:
-      - src/**
-      - docs/**
-      - tests/**
-      - .github/workflows/**
+      - src/**/*
+      - docs/**/*
+      - tests/**/*
+      - .github/workflows/**/*
       - .github/labeler.yaml
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Add Binaries to Release
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
   add_binaries:


### PR DESCRIPTION
Fix globs in workflows not covering all subfolders (change
`folder/**` to `folder/**/*`)