### PR TITLE
Update build workflow paths

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -6,12 +6,14 @@ on:
     paths:
       - src/**
       - tests/**
+      - Cargo.*
   push:
     branches:
       - master
     paths:
       - src/**
       - tests/**
+      - Cargo.*
 
 jobs:
   windows_build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,8 @@
 name: Add Binaries to Release
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 jobs:
   add_binaries:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-# test commit
 [package]
 version = "0.6.1"
 name = "databind"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+# test commit
 [package]
 version = "0.6.1"
 name = "databind"


### PR DESCRIPTION
Makes the Build And Test workflow run when the Cargo.toml or Cargo.lock
files are changed as well as the source/test directories.