### PR TITLE
Fix macro call escaping

### DIFF
--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -325,7 +325,12 @@ impl Compiler {
                 } else {
                     if in_string {
                         if self.current_char == '\\' {
-                            escaping_string = true;
+                            if escaping_string {
+                                escaping_string = false;
+                                current_string.push(self.current_char);
+                            } else {
+                                escaping_string = true;
+                            }
                         } else if self.current_char == '"' && !escaping_string {
                             in_string = false;
                             macro_args.push(current_string);
@@ -334,6 +339,7 @@ impl Compiler {
                             continue;
                         } else {
                             current_string.push(self.current_char);
+                            escaping_string = false;
                         }
                     } else {
                         if self.current_char == '"' {

--- a/tests/file_contents_tests.rs
+++ b/tests/file_contents_tests.rs
@@ -308,3 +308,17 @@ fn test_macro_defs_in_defs() {
     let contents = fs::read_to_string(&out_path).unwrap();
     assert!(contents.contains("say Hello from new macro"));
 }
+
+/// Test that ecaped characters work in macros
+#[test]
+fn test_macro_escape() {
+    let out = tests::run_in_tempdir("test_macro_escape").0;
+    let out_path = format!(
+        "{}/data/test/functions/main.mcfunction",
+        out.path().display()
+    );
+
+    let contents = fs::read_to_string(&out_path).unwrap();
+    assert!(contents.contains("say Quote: \""));
+    assert!(contents.contains("say Backslash: \\"));
+}

--- a/tests/resources/test_macro_escape/data/test/functions/main.databind
+++ b/tests/resources/test_macro_escape/data/test/functions/main.databind
@@ -1,0 +1,8 @@
+!def escape_test($msg)
+    say $msg
+!end
+
+func main
+    ?escape_test("Quote: \"")
+    ?escape_test("Backslash: \\")
+end


### PR DESCRIPTION
Fixes a bug where escaped double quotes in macro calls would cause a
stack overflow.

- [x] Fix escaping
- [x] Add escape test