### PR TITLE
Make tests properly use --release flag

### DIFF
--- a/tests/file_structure_tests.rs
+++ b/tests/file_structure_tests.rs
@@ -77,19 +77,32 @@ fn test_config() {
 
     let out = TempDir::new("test_config").expect("Could not create tempdir for test");
 
-    tests::run_with_args(
-        "cargo",
-        &[
+    let toml_path = format!("{}/databind.toml", path_str);
+
+    let args = if cfg!(debug_assertions) {
+        vec![
             "run",
             "--",
             path_str,
             "--config",
-            &format!("{}/databind.toml", path_str)[..],
+            &toml_path,
             "--out",
             out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+        ]
+    } else {
+        vec![
+            "run",
+            "--release",
+            "--",
+            path_str,
+            "--config",
+            &toml_path,
+            "--out",
+            out.path().to_str().unwrap(),
+        ]
+    };
+
+    tests::run_with_args("cargo", &args, None);
 
     let expected_funcs = ["func1.mcfunction", "func2.mcfunction", "func3.mcfunction"];
 
@@ -107,19 +120,32 @@ fn test_no_config_out() {
 
     let out = TempDir::new("test_no_config_out").expect("Could not create tempdir for test");
 
-    tests::run_with_args(
-        "cargo",
-        &[
+    let toml_path = format!("{}/should_not_be_made.toml", path_str);
+
+    let args = if cfg!(debug_assertions) {
+        vec![
             "run",
             "--",
             path_str,
             "--config",
-            &format!("{}/should_not_be_made.toml", path_str)[..],
+            &toml_path,
             "--out",
             out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+        ]
+    } else {
+        vec![
+            "run",
+            "--release",
+            "--",
+            path_str,
+            "--config",
+            &toml_path,
+            "--out",
+            out.path().to_str().unwrap(),
+        ]
+    };
+
+    tests::run_with_args("cargo", &args, None);
 
     let expected_funcs = ["tick.mcfunction"];
     let expected_toml = ["should_be_made.toml"];
@@ -192,33 +218,43 @@ fn test_databind_alone() {
     let out = TempDir::new("test_databind_alone").expect("Could not create tempdir for test");
     let mut path = PathBuf::from(out.path());
 
-    // Create project
-    tests::run_with_args(
-        "cargo",
-        &[
+    let args = if cfg!(debug_assertions) {
+        vec![
             "run",
             "--",
             "create",
             "test_databind_alone",
             "--path",
             out.path().to_str().unwrap(),
-        ],
-        None,
-    );
+        ]
+    } else {
+        vec![
+            "run",
+            "--release",
+            "--",
+            "create",
+            "test_databind_alone",
+            "--path",
+            out.path().to_str().unwrap(),
+        ]
+    };
+
+    // Create project
+    tests::run_with_args("cargo", &args, None);
 
     path.push("src");
     println!("running in path: {}", path.display());
 
+    let manifest_path = format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"));
+
+    let args = if cfg!(debug_assertions) {
+        vec!["run", "--manifest-path", &manifest_path]
+    } else {
+        vec!["run", "--release", "--manifest-path", &manifest_path]
+    };
+
     // Run `databind` in directory
-    tests::run_with_args(
-        "cargo",
-        &[
-            "run",
-            "--manifest-path",
-            &format!("{}/Cargo.toml", env!("CARGO_MANIFEST_DIR"))[..],
-        ],
-        Some(&path),
-    );
+    tests::run_with_args("cargo", &args, Some(&path));
 
     // Pop /src from the path to check for /out in the project root
     path.pop();

--- a/tests/other_tests.rs
+++ b/tests/other_tests.rs
@@ -30,9 +30,8 @@ fn test_create_structure() {
     let out = TempDir::new("test_create_structure").expect("Could not create tempdir for test");
     let mut path = PathBuf::from(out.path());
 
-    tests::run_with_args(
-        "cargo",
-        &[
+    let args = if cfg!(debug_assertions) {
+        vec![
             "run",
             "--",
             "create",
@@ -41,9 +40,22 @@ fn test_create_structure() {
             out.path().to_str().unwrap(),
             "--desc",
             "test_create_structure description",
-        ],
-        None,
-    );
+        ]
+    } else {
+        vec![
+            "run",
+            "--release",
+            "--",
+            "create",
+            "test_create_structure",
+            "--path",
+            out.path().to_str().unwrap(),
+            "--desc",
+            "test_create_structure description",
+        ]
+    };
+
+    tests::run_with_args("cargo", &args, None);
     // Check that the folder was created
     assert!(path.exists() && path.is_dir());
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -91,18 +91,28 @@ pub fn check_files_dont_exist<P: AsRef<Path>>(
 
 /// Run Databind on a path and send output to a path
 pub fn run<P: AsRef<Path>>(out: P, path: P) {
-    run_with_args(
-        "cargo",
-        &[
+    let args = if cfg!(debug_assertions) {
+        vec![
             "run",
             "--",
             path.as_ref().to_str().unwrap(),
             "--ignore-config",
             "--out",
             out.as_ref().to_str().unwrap(),
-        ],
-        None,
-    );
+        ]
+    } else {
+        vec![
+            "run",
+            "--release",
+            "--",
+            path.as_ref().to_str().unwrap(),
+            "--ignore-config",
+            "--out",
+            out.as_ref().to_str().unwrap(),
+        ]
+    };
+
+    run_with_args("cargo", &args, None);
 }
 
 /// Create a temporary output directory for a test and run


### PR DESCRIPTION
Closes #118 

Uses the `debug_assertions` cfg option to tell if the test is for
release or debug. This prevents tests from having to re-build the binary
when it's been built for release.