### PR TITLE
Fix modulus operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the modulus operator for scoreboard player operations (`%=`)
+  being replaced with an assignment operator (`=`)
+
 ## [0.6.3] - August 12, 2021
 
 ### Changed

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -440,7 +440,9 @@ impl Compiler {
                             "sbop" => no_args_add!(Token::ScoreboardOperation),
                             "delvar" | "delobj" => set_building!(Token::DeleteVar, 1),
                             _ => {
-                                if current_token.starts_with('%') {
+                                if current_token.starts_with('%')
+                                    && !current_token.starts_with("%=")
+                                {
                                     no_args_add!(Token::NonDatabind(format!(
                                         "{} ",
                                         current_token.strip_prefix('%').unwrap()

--- a/tests/file_contents_tests.rs
+++ b/tests/file_contents_tests.rs
@@ -322,3 +322,19 @@ fn test_macro_escape() {
     assert!(contents.contains("say Quote: \""));
     assert!(contents.contains("say Backslash: \\"));
 }
+
+/// Test that the modulus operator is not treated as an escaped
+/// equals sign
+#[test]
+fn test_modulus_operator() {
+    let out = tests::run_in_tempdir("test_modulus_operator").0;
+    let out_path = format!(
+        "{}/data/test/functions/main.mcfunction",
+        out.path().display()
+    );
+
+    let contents = fs::read_to_string(&out_path).unwrap();
+    assert!(
+        contents.contains("scoreboard players operation testplayer score1 %= testplayer score2")
+    );
+}

--- a/tests/resources/test_modulus_operator/data/test/functions/main.databind
+++ b/tests/resources/test_modulus_operator/data/test/functions/main.databind
@@ -1,0 +1,3 @@
+func main
+    scoreboard players operation testplayer score1 %= testplayer score2
+end


### PR DESCRIPTION
Closes #122

Fixes the modulus operator (`%=`) being replaced with an assignment operator (`=`).
Also adds a test to make sure that everything works properly.