### PR TITLE
Fix `sbop` keyword not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the `sbop` keyword not outputting valid code
+
 ## [0.6.3] - August 12, 2021
 
 ### Changed

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -117,12 +117,12 @@ impl Compiler {
         }
     }
 
-    /// Replace while loops, if statements, and scoreboard operations.
+    /// Replace while loops and if statements.
     /// Called recursively until none are left
     ///
     /// # Arguments
     ///
-    /// - `tokens` - A list of tokens to look for while loops or `sbop`'s in
+    /// - `tokens` - A list of tokens to look for while loops or if statements in
     /// - `subfolder` - If the while loop is in a subfolder, the prefix
     ///   to put before the function name (eg. `"cmd/"` for a subfolder named `cmd`)
     pub fn parse_shorthand(&self, tokens: Vec<Token>, subfolder: &str) -> Vec<Token> {
@@ -229,10 +229,6 @@ impl Compiler {
                             chars, contents
                         ))
                     }
-                }
-                Token::ScoreboardOperation => {
-                    new_tokens[i + index_offset] =
-                        Token::NonDatabind("scoreboard players operation ".into());
                 }
                 _ => {}
             }

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -236,14 +236,10 @@ impl Compiler {
 
         // Run recursively until no if statements, while loops,
         // or scoreboard operations are left
-        if new_tokens.iter().any(|x| {
-            [
-                Token::IfStatement,
-                Token::WhileLoop,
-                Token::ScoreboardOperation,
-            ]
-            .contains(&x)
-        }) {
+        if new_tokens
+            .iter()
+            .any(|x| [Token::IfStatement, Token::WhileLoop].contains(&x))
+        {
             self.parse_shorthand(new_tokens, subfolder)
         } else {
             new_tokens

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -437,7 +437,9 @@ impl Compiler {
                                 building_condition = true;
                                 self.next_char();
                             }
-                            "sbop" => no_args_add!(Token::ScoreboardOperation),
+                            "sbop" => no_args_add!(Token::NonDatabind(
+                                "scoreboard players operation ".into()
+                            )),
                             "delvar" | "delobj" => set_building!(Token::DeleteVar, 1),
                             _ => {
                                 if current_token.starts_with('%') {

--- a/src/token.rs
+++ b/src/token.rs
@@ -83,8 +83,6 @@ pub enum Token {
     VarAdd,
     /// Subtract from the value of a variable or objective
     VarSub,
-    /// Shorthand for `scoreboard players operation`
-    ScoreboardOperation,
     /// An integer
     Int(i32),
     /// Define a Databind macro


### PR DESCRIPTION
Closes #123 

Fixes the `sbop` keyword for scoreboard operations not being replaced properly. The original way to replace it was actually a very weird way to go about it, so I'm not sure why it was added that way in the first place. Wonder who did that?
