### PR TITLE
Add line and column numbers to error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Filenames and line/column numbers to error messages
+
 ## [0.6.4] - August 19, 2021
 
 ### Fixed

--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -167,7 +167,7 @@ impl Compiler {
                 }
                 Token::TagName(tag) => {
                     if func_depth == 0 {
-                        println!("error: Tag found outside of function.");
+                        println!("error: {} - Tag found outside of function.", self.path);
                         std::process::exit(1);
                     }
 

--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -167,7 +167,7 @@ impl Compiler {
                 }
                 Token::TagName(tag) => {
                     if func_depth == 0 {
-                        println!("Tag found outside of function.");
+                        println!("error: Tag found outside of function.");
                         std::process::exit(1);
                     }
 

--- a/src/compiler/compile.rs
+++ b/src/compiler/compile.rs
@@ -167,8 +167,7 @@ impl Compiler {
                 }
                 Token::TagName(tag) => {
                     if func_depth == 0 {
-                        println!("error: {} - Tag found outside of function.", self.path);
-                        std::process::exit(1);
+                        panic!("error: Tag found outside function. This token should have been ignored");
                     }
 
                     tag_map

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -61,8 +61,9 @@ impl Compiler {
             if self.current_char == '\n' {
                 self.line += 1;
                 self.col = 0;
+            } else {
+                self.col += 1;
             }
-            self.col += 1;
         } else {
             self.current_char = '\u{0}'
         }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -20,6 +20,8 @@ pub struct Compiler {
     chars: Vec<char>,
     position: usize,
     current_char: char,
+    line: usize,
+    col: usize,
 }
 
 impl Compiler {
@@ -39,6 +41,8 @@ impl Compiler {
             chars: text.chars().filter(|x| *x != '\r').collect(),
             position: 0,
             current_char: first_char,
+            line: 1,
+            col: 1,
         }
     }
 
@@ -47,9 +51,18 @@ impl Compiler {
         self.position += 1;
         if self.position < self.chars.len() {
             self.current_char = self.chars[self.position];
+            if self.current_char == '\n' {
+                self.line += 1;
+                self.col = 0;
+            }
+            self.col += 1;
         } else {
             self.current_char = '\u{0}'
         }
+    }
+
+    pub fn make_syntax_error(&self, message: &str) -> String {
+        format!("error: {}:{} - {}", self.line, self.col, message)
     }
 }
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -22,6 +22,7 @@ pub struct Compiler {
     current_char: char,
     line: usize,
     col: usize,
+    path: String,
 }
 
 impl Compiler {
@@ -30,7 +31,8 @@ impl Compiler {
     /// # Arguments
     ///
     /// - `text` - The contents of the file to compile
-    pub fn new(text: String) -> Compiler {
+    /// - `path` - The path of the file being compiled. Used for error messages
+    pub fn new(text: String, path: Option<String>) -> Compiler {
         let first_char = if !text.is_empty() {
             text.chars().next().unwrap()
         } else {
@@ -43,6 +45,11 @@ impl Compiler {
             current_char: first_char,
             line: 1,
             col: 1,
+            path: if let Some(p) = path {
+                p
+            } else {
+                "INTERNAL".into()
+            },
         }
     }
 
@@ -62,7 +69,10 @@ impl Compiler {
     }
 
     pub fn make_syntax_error(&self, message: &str) -> String {
-        format!("error: {}:{} - {}", self.line, self.col, message)
+        format!(
+            "error: {}:{}:{} - {}",
+            self.path, self.line, self.col, message
+        )
     }
 }
 

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -68,8 +68,8 @@ impl Compiler {
                             continue;
                         } else {
                             println!(
-                                "error: A non-existant macro {} was called",
-                                active_macro_name
+                                "error: {} - A non-existant macro {} was called",
+                                self.path, active_macro_name
                             );
                             std::process::exit(1);
                         }
@@ -77,7 +77,7 @@ impl Compiler {
 
                     let tks = {
                         let new_contents = macros[&active_macro_name].replace(args);
-                        Compiler::new(new_contents.clone()).tokenize()
+                        Compiler::new(new_contents.clone(), None).tokenize()
                     };
 
                     // Remove the tokens CallMacro, MacroName, and CallArgList
@@ -145,7 +145,7 @@ impl Compiler {
                 chars = Compiler::random_chars();
 
                 // Tokenize new contents
-                let tks = Compiler::new(new_contents.clone()).tokenize();
+                let tks = Compiler::new(new_contents.clone(), None).tokenize();
                 new_contents = String::new();
 
                 // When gettings indexes in the new tokens vector,

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -47,6 +47,8 @@ impl Compiler {
         let mut call_index: usize = 0;
         let mut define_index: usize = 0;
         let mut index_offset: usize = 0;
+        let mut macro_line: usize = 0;
+        let mut macro_col: usize = 0;
 
         let mut active_macro_name = String::new();
         let mut macro_def_args: Vec<String> = Vec::new();
@@ -56,7 +58,12 @@ impl Compiler {
             match token {
                 Token::CallMacro => call_index = i,
                 Token::DefineMacro => define_index = i,
-                Token::MacroName(name) => active_macro_name = name.clone(),
+                Token::MacroName(name, line, col) => {
+                    active_macro_name = name.clone();
+                    macro_line = *line;
+                    macro_col = *col;
+                }
+
                 Token::DefArgList(args) => {
                     macro_def_args = args.clone();
                 }
@@ -68,8 +75,8 @@ impl Compiler {
                             continue;
                         } else {
                             println!(
-                                "error: {} - A non-existant macro {} was called",
-                                self.path, active_macro_name
+                                "error: {}:{}:{} - A non-existant macro {} was called",
+                                self.path, macro_line, macro_col, active_macro_name
                             );
                             std::process::exit(1);
                         }

--- a/src/compiler/preprocess.rs
+++ b/src/compiler/preprocess.rs
@@ -67,7 +67,10 @@ impl Compiler {
                         if new_tokens.contains(&Token::DefineMacro) {
                             continue;
                         } else {
-                            println!("A non-existant macro {} was called", active_macro_name);
+                            println!(
+                                "error: A non-existant macro {} was called",
+                                active_macro_name
+                            );
                             std::process::exit(1);
                         }
                     }

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -123,7 +123,10 @@ impl Compiler {
                 } else if DIGITS.contains(&self.current_char) {
                     current_token.push(self.current_char);
                 } else {
-                    println!("[ERROR] Variables can only store integers.");
+                    println!(
+                        "{}",
+                        self.make_syntax_error("Variables can only store integers")
+                    );
                     std::process::exit(1);
                 }
             };
@@ -159,7 +162,10 @@ impl Compiler {
                             }
                         };
                     } else {
-                        println!("Invalid assignment operator provided");
+                        println!(
+                            "{}",
+                            self.make_syntax_error("Invalid assignment operator provided")
+                        );
                         std::process::exit(1);
                     }
                     params_left -= 1;
@@ -265,7 +271,10 @@ impl Compiler {
                             self.next_char();
                             continue;
                         } else if self.current_char != '$' {
-                            println!("[ERROR] Macro arguments must be preceded by a '$', eg. !def macro($arg1 $arg2)");
+                            println!(
+                                "{}",
+                                self.make_syntax_error("Macro arguments must be preceded by a '$', eg. !def macro($arg1, $arg2)")
+                            );
                             std::process::exit(1);
                         }
                         building_macro_arg = true;
@@ -317,8 +326,11 @@ impl Compiler {
                         building_macro_arg = true;
                     } else if !self.current_char.is_whitespace() {
                         println!(
-                            "[ERROR] A '(' was expected to start the argument list for call of macro {}",
-                            macro_name
+                            "{}",
+                            self.make_syntax_error(&format!(
+                                "'(' was expected to start the argument list for call of macro {}",
+                                macro_name
+                            ))
                         );
                         std::process::exit(1);
                     }
@@ -353,8 +365,11 @@ impl Compiler {
                             self.next_char();
                         } else if self.current_char != ',' && !self.current_char.is_whitespace() {
                             println!(
-                                "[ERROR] Unexpected character {:?} found in macro call",
-                                self.current_char
+                                "{}",
+                                self.make_syntax_error(&format!(
+                                    "Unexpected character {:?} found in macro call",
+                                    self.current_char
+                                ))
                             );
                             std::process::exit(1);
                         }

--- a/src/compiler/tokenize.rs
+++ b/src/compiler/tokenize.rs
@@ -139,7 +139,7 @@ impl Compiler {
                 calling_macro = true;
                 macro_name = current_token.strip_prefix('?').unwrap().into();
                 no_args_add!(Token::CallMacro);
-                tokens.push(Token::MacroName(macro_name.clone()));
+                tokens.push(Token::MacroName(macro_name.clone(), self.line, self.col));
             };
         }
 
@@ -252,7 +252,7 @@ impl Compiler {
                     if self.current_char != '(' && !self.current_char.is_whitespace() {
                         macro_name.push(self.current_char);
                     } else if self.current_char == '(' {
-                        tokens.push(Token::MacroName(macro_name));
+                        tokens.push(Token::MacroName(macro_name, self.line, self.col));
                         macro_name = String::new();
                         macro_name_built = true;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,7 +337,10 @@ fn main() -> std::io::Result<()> {
                     }
                     file_contents
                 };
-                let mut compile = compiler::Compiler::new(contents);
+                let mut compile = compiler::Compiler::new(
+                    contents,
+                    Some(path.canonicalize().unwrap().to_str().unwrap().into()),
+                );
                 let tokens = compile.tokenize();
 
                 let mut compiled = if path.file_name().unwrap().to_str().unwrap().starts_with('!') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,7 @@ fn main() -> std::io::Result<()> {
                         Value::Integer(value) => value.to_string(),
                         Value::Datetime(value) => value.to_string(),
                         _ => {
-                            println!("[ERROR] Unsupported type found in vars.toml file (key: {}, value: {})", k, v);
+                            println!("error: Unsupported type found in vars.toml file (key: {}, value: {})", k, v);
                             std::process::exit(1);
                         }
                     };

--- a/src/token.rs
+++ b/src/token.rs
@@ -90,7 +90,10 @@ pub enum Token {
     /// Call a Databind macro
     CallMacro,
     /// The name of a Databind macro
-    MacroName(String),
+    ///
+    /// The first `usize` is for the line with the macro name,
+    /// and the second is for the column
+    MacroName(String, usize, usize),
     /// The contents of a macro
     MacroContents(String),
     /// Close a Databind macro definition


### PR DESCRIPTION
Closes #127 

- [x] Add line and column numbers to error messages
  - [x] Messages from `tokenize.rs`
  - [x] Messages from `preprocess.rs`
- [x] Add filenames to error messages
