### PR TITLE
Add `--locked` to all cargo commands

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -40,10 +40,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
-        run: cargo build --release --all-features
+        run: cargo build --release --all-features --locked
 
       - name: Test
-        run: cargo test --release --all-features
+        run: cargo test --release --all-features --locked
 
       - name: Upload release binary
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -77,10 +77,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
-        run: cargo build --release --all-features
+        run: cargo build --release --all-features --locked
 
       - name: Test
-        run: cargo test --release --all-features
+        run: cargo test --release --all-features --locked
 
       - name: Upload release binary
         if: ${{ github.ref == 'refs/heads/master' }}
@@ -114,10 +114,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
-        run: cargo build --release --all-features
+        run: cargo build --release --all-features --locked
 
       - name: Test
-        run: cargo test --release --all-features
+        run: cargo test --release --all-features --locked
 
       - name: Upload release binary
         if: ${{ github.ref == 'refs/heads/master' }}

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ To run Databind after building it with `cargo build`, use `cargo run`.
 
 ### From crates.io
 
-To download Databind from crates.io, run `cargo install databind`. If Rust is
+To download Databind from crates.io, run `cargo install databind --locked`. If Rust is
 [in your PATH](https://www.rust-lang.org/tools/install#installation-notes),
 then running `databind` from a command line will work.
 
 ### Locally
 
-To install Databind from a cloned repository, run `cargo install --path .` in the root directory.
+To install Databind from a cloned repository, run `cargo install --path . --locked` in the root directory.
 
 ## Documentation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+// Trigger workflows
 #![warn(clippy::all)]
 
 use same_file::is_same_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-// Trigger workflows
 #![warn(clippy::all)]
 
 use same_file::is_same_file;


### PR DESCRIPTION
Adds the --locked flag to all cargo commands to make sure that builds do not start failing without the Cargo.lock file changing. This includes the install instructions in the README.md file and the CLI docs.