### PR TITLE
Allow function definitions with slashes

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -192,9 +192,11 @@ fn main() -> std::io::Result<()> {
                 );
 
                 for (key, value) in compiled.filename_map.iter() {
-                    let full_path = format!("{}/{}.mcfunction", target_path, key);
+                    let full_path_string = format!("{}/{}.mcfunction", target_path, key);
+                    let full_path = Path::new(&full_path_string);
 
-                    fs::write(full_path, &compiled.file_contents[*value])?;
+                    fs::create_dir_all(&full_path.parent().unwrap())?;
+                    fs::write(&full_path, &compiled.file_contents[*value])?;
 
                     // Add namespace prefix to function in tag map
                     for (_, funcs) in compiled.tag_map.iter_mut() {


### PR DESCRIPTION
Closes #136

Allows functions to be defined with slashes in the name to create functions in subdirectories. This avoids being forced to split your code further if you want to have a function with a prefix like `cmd/`.