### PR TITLE
Fix subdir tags overwriting/being overwritten

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -210,7 +210,12 @@ fn main() -> std::io::Result<()> {
                     }
                 }
 
-                tag_map.extend(compiled.tag_map);
+                for (key, value) in compiled.tag_map {
+                    tag_map
+                        .entry(key)
+                        .or_insert(Vec::new())
+                        .append(&mut value.clone());
+                }
             } else {
                 let filename = relative_path.file_name().unwrap().to_str().unwrap();
                 let full_path = format!("{}/{}", target_path, filename);


### PR DESCRIPTION
Closes #138

Fixes a problem where tagged functions in subdirectories would overwrite tags defined earlier or be overwritten by tags defined later. This problem was caused by the use of the `HashMap::extend` function, which actually replaces the value of each key if it already exists.