### PR TITLE
Fix get_namespace tag problems

### DIFF
--- a/src/lib/compiler/mod.rs
+++ b/src/lib/compiler/mod.rs
@@ -108,7 +108,7 @@ impl Compiler {
         if target_filename.starts_with('!') {
             let ret = self.compile(
                 tokens,
-                Some(files::get_namespace(&functions_dir).unwrap()),
+                Some(&files::get_namespace(&functions_dir).unwrap()),
                 &files::get_subfolder_prefix(&functions_dir),
                 &global_macros,
                 true,
@@ -118,7 +118,7 @@ impl Compiler {
         } else {
             self.compile(
                 tokens,
-                Some(files::get_namespace(&functions_dir).unwrap()),
+                Some(&files::get_namespace(&functions_dir).unwrap()),
                 &files::get_subfolder_prefix(&functions_dir),
                 &global_macros,
                 false,

--- a/src/lib/files.rs
+++ b/src/lib/files.rs
@@ -58,24 +58,30 @@ pub fn get_subfolder_prefix<P: AsRef<Path>>(functions_path: &P) -> String {
 }
 
 /// Get namespace (name of folder containing the main /functions)
-pub fn get_namespace<P: AsRef<Path>>(functions_path: &P) -> Result<&str, &str> {
-    let namespace_folder = functions_path
-        .as_ref()
-        .to_str()
-        .unwrap()
-        .split("functions")
-        .next()
-        .unwrap();
+pub fn get_namespace<P: AsRef<Path>>(functions_path: &P) -> Result<String, &str> {
+    let namespace_str = {
+        let mut namespace_buf = functions_path.as_ref().to_path_buf();
+        while namespace_buf.is_file()
+            && namespace_buf.file_name().unwrap().to_str().unwrap() != "functions"
+        {
+            namespace_buf.pop();
+        }
+        namespace_buf.pop();
+
+        namespace_buf.to_str().unwrap().to_string()
+    };
 
     let namespace_folder =
-        if let Some(new) = namespace_folder.strip_suffix(|x: char| ['\\', '/'].contains(&x)) {
-            new
+        if let Some(new) = namespace_str.strip_suffix(|x: char| ['\\', '/'].contains(&x)) {
+            new.to_string()
         } else {
-            namespace_folder
+            namespace_str
         };
 
     let folders = namespace_folder.split(|x: char| ['\\', '/'].contains(&x));
-    Ok(folders.last().unwrap())
+    let last = folders.last().unwrap().to_string();
+
+    Ok(last)
 }
 
 /// Convert multiple globs into a `Vec<PathBuf>`


### PR DESCRIPTION
Closes #140

Fixes a problem where `files::get_namespace` wouldn't work properly if the path contained the word `functions` at any point. This is actually not backwards-compatible due to the change of return type from `Result<&str, &str>` to `Result<String, &str>`, but the API isn't stable and isn't used by anyone else so it seems ok to release as a patch.